### PR TITLE
Fix create account UI overflow

### DIFF
--- a/lib/utils/ui/scrollable_if_too_high.dart
+++ b/lib/utils/ui/scrollable_if_too_high.dart
@@ -1,0 +1,28 @@
+import "package:flutter/widgets.dart";
+
+class ScrollableIfTooHigh extends StatelessWidget {
+  final Widget child;
+
+  const ScrollableIfTooHigh({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints viewportConstraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: viewportConstraints.maxHeight,
+            ),
+            child: IntrinsicHeight(
+              child: child,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/utils/ui/scrollable_if_too_high.dart
+++ b/lib/utils/ui/scrollable_if_too_high.dart
@@ -1,5 +1,8 @@
 import "package:flutter/widgets.dart";
 
+/// Widget that will be scrollable if its content is too high. This wraps
+/// [[SingleChildScrollView]], as presented in its documentation:
+/// https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html
 class ScrollableIfTooHigh extends StatelessWidget {
   final Widget child;
 

--- a/lib/utils/ui/scrollable_if_too_high.dart
+++ b/lib/utils/ui/scrollable_if_too_high.dart
@@ -1,7 +1,8 @@
 import "package:flutter/widgets.dart";
 
 /// Widget that will be scrollable if its content is too high. This wraps
-/// [[SingleChildScrollView]], as presented in its documentation:
+/// [[SingleChildScrollView]] in a way that supports flexible-sized widgets,
+/// as presented in its documentation:
 /// https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html
 class ScrollableIfTooHigh extends StatelessWidget {
   final Widget child;

--- a/lib/views/pages/create_account_page.dart
+++ b/lib/views/pages/create_account_page.dart
@@ -29,7 +29,7 @@ class CreateAccountPage extends HookConsumerWidget {
         title: const Text("Create your account"),
       ),
       body: const Padding(
-        padding: EdgeInsets.only(left: 50, right: 50, top: 50, bottom: 50),
+        padding: EdgeInsets.only(left: 50, right: 50),
         child: Center(child: _CreateAccountPageContent()),
       ),
     );
@@ -46,6 +46,7 @@ class _CreateAccountPageContent extends HookConsumerWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         children: [
           Flexible(flex: 20, child: Container()),
+          const SizedBox(height: 20),
           const TextField(
             key: CreateAccountPage.uniqueUsernameFieldKey,
             decoration: InputDecoration(
@@ -62,6 +63,7 @@ class _CreateAccountPageContent extends HookConsumerWidget {
             ),
           ),
           Flexible(flex: 50, child: Container()),
+          const SizedBox(height: 50),
           ElevatedButton(
             key: CreateAccountPage.confirmButtonKey,
             onPressed: () {
@@ -70,6 +72,8 @@ class _CreateAccountPageContent extends HookConsumerWidget {
             },
             child: const Text("Confirm"),
           ),
+          Flexible(flex: 20, child: Container()),
+          const SizedBox(height: 20),
         ],
       ),
     );

--- a/lib/views/pages/create_account_page.dart
+++ b/lib/views/pages/create_account_page.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/utils/ui/scrollable_if_too_high.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
 import "package:proxima/views/navigation/routes.dart";
 
@@ -40,35 +41,37 @@ class _CreateAccountPageContent extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        Flexible(flex: 20, child: Container()),
-        const TextField(
-          key: CreateAccountPage.uniqueUsernameFieldKey,
-          decoration: InputDecoration(
-            labelText: "Unique username",
-            border: OutlineInputBorder(),
+    return ScrollableIfTooHigh(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Flexible(flex: 20, child: Container()),
+          const TextField(
+            key: CreateAccountPage.uniqueUsernameFieldKey,
+            decoration: InputDecoration(
+              labelText: "Unique username",
+              border: OutlineInputBorder(),
+            ),
           ),
-        ),
-        const SizedBox(height: 20),
-        const TextField(
-          key: CreateAccountPage.pseudoFieldKey,
-          decoration: InputDecoration(
-            labelText: "Pseudo",
-            border: OutlineInputBorder(),
+          const SizedBox(height: 20),
+          const TextField(
+            key: CreateAccountPage.pseudoFieldKey,
+            decoration: InputDecoration(
+              labelText: "Pseudo",
+              border: OutlineInputBorder(),
+            ),
           ),
-        ),
-        Flexible(flex: 50, child: Container()),
-        ElevatedButton(
-          key: CreateAccountPage.confirmButtonKey,
-          onPressed: () {
-            // TODO: Also store this to the database
-            Navigator.pushReplacementNamed(context, Routes.home.name);
-          },
-          child: const Text("Confirm"),
-        ),
-      ],
+          Flexible(flex: 50, child: Container()),
+          ElevatedButton(
+            key: CreateAccountPage.confirmButtonKey,
+            onPressed: () {
+              // TODO: Also store this to the database
+              Navigator.pushReplacementNamed(context, Routes.home.name);
+            },
+            child: const Text("Confirm"),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Fixes #51. 

More than rendering the view scrollable, I also added some minimum spacing between the widgets. 

Note that I needed to create some `ScrollableIfTooHigh` widget, to handle widgets with a flexible size (this is the case for my spacer). This was strongly inspired from [the documentation](https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html).

The things I am least sure about and that might be interesting for you to consider:
- `ScrollableIfTooHigh` is in `utils/ui`. This makes sense in my opinion, since this is also where `CircularValue` is; but I am not completely sure.
- I tend to always use `Flexible` followed by `SizedBox` in order to have a minimum spacing between widgets, which is increased in a flexible way. I did not find something that would encapsulate the two in the same widget in the documentation, or a better way to do it; but not finding something does not mean it does not exit.

I tested it on a small screen emulator, and on my phone horizontally (commenting out the line preventing to do so in `main.dart`), which you can see hereinbelow. 

<p align="center">
<image width=30% src="https://github.com/ProximaEPFL/proxima/assets/22430066/ec4a5913-f963-487c-a4f7-9af0ce4a8a40">
<video src="https://github.com/ProximaEPFL/proxima/assets/22430066/688bebd8-5ac2-4a1b-ac0b-9ff7aee021e8">
</p>
