### PR TITLE
fix(test): use the right imports in new_post_test

### DIFF
--- a/test/component/new_post_test.dart
+++ b/test/component/new_post_test.dart
@@ -5,8 +5,8 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/views/pages/new_post/new_post_form.dart";
 import "package:proxima/views/pages/new_post/new_post_page.dart";
 
-import "utils/firebase/setup_firebase_mocks.dart";
-import "utils/firebase/testing_login_providers.dart";
+import "../services/firebase/setup_firebase_mocks.dart";
+import "../services/firestore/testing_firestore_provider.dart";
 
 void main() {
   setupFirebaseAuthMocks();


### PR DESCRIPTION
This PR aims to fix the imports in `test/component/new_post_test.dart` that were made obselete when merging the PR "Add repositories for user and post" (due to the refactoring that happened in it).