### PR TITLE
Mock repositories

### DIFF
--- a/test/models/database/post/mock_post_data.dart
+++ b/test/models/database/post/mock_post_data.dart
@@ -8,7 +8,7 @@ import "package:proxima/models/database/user/user_id_firestore.dart";
 
 /// Helper class to create mock post data to be used in tests
 class MockPostFirestore {
-  PostFirestore createPostAt(
+  static PostFirestore createPostAt(
     PostData data,
     GeoPoint location, {
     id = "post_id",
@@ -25,7 +25,7 @@ class MockPostFirestore {
     );
   }
 
-  List<PostData> generatePostData(int count) {
+  static List<PostData> generatePostData(int count) {
     return List.generate(count, (i) {
       return PostData(
         description: "description_$i",

--- a/test/models/database/post/mock_post_data.dart
+++ b/test/models/database/post/mock_post_data.dart
@@ -6,6 +6,7 @@ import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/database/post/post_location_firestore.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
 
+/// Helper class to create mock post data to be used in tests
 class MockPostFirestore {
   PostFirestore createPostAt(
     PostData data,

--- a/test/models/database/user/mock_user_data.dart
+++ b/test/models/database/user/mock_user_data.dart
@@ -4,6 +4,7 @@ import "package:proxima/models/database/user/user_data.dart";
 import "package:proxima/models/database/user/user_firestore.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
 
+/// Helper class to generate mock user data to be used in tests
 class MockUserFirestore {
   List<UserData> generateUserData(int count) {
     return List.generate(count, (i) {

--- a/test/models/database/user/mock_user_data.dart
+++ b/test/models/database/user/mock_user_data.dart
@@ -1,0 +1,26 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:collection/collection.dart";
+import "package:proxima/models/database/user/user_data.dart";
+import "package:proxima/models/database/user/user_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+
+class MockUserFirestore {
+  List<UserData> generateUserData(int count) {
+    return List.generate(count, (i) {
+      return UserData(
+        displayName: "display_name_$i",
+        username: "username_$i",
+        joinTime: Timestamp.fromMillisecondsSinceEpoch(1000 * i),
+      );
+    });
+  }
+
+  List<UserFirestore> generateUserFirestore(int count) {
+    return generateUserData(count).mapIndexed((i, data) {
+      return UserFirestore(
+        uid: UserIdFirestore(value: "user_id_$i"),
+        data: data,
+      );
+    }).toList();
+  }
+}

--- a/test/models/database/user/mock_user_data.dart
+++ b/test/models/database/user/mock_user_data.dart
@@ -6,7 +6,7 @@ import "package:proxima/models/database/user/user_id_firestore.dart";
 
 /// Helper class to generate mock user data to be used in tests
 class MockUserFirestore {
-  List<UserData> generateUserData(int count) {
+  static List<UserData> generateUserData(int count) {
     return List.generate(count, (i) {
       return UserData(
         displayName: "display_name_$i",
@@ -16,7 +16,7 @@ class MockUserFirestore {
     });
   }
 
-  List<UserFirestore> generateUserFirestore(int count) {
+  static List<UserFirestore> generateUserFirestore(int count) {
     return generateUserData(count).mapIndexed((i, data) {
       return UserFirestore(
         uid: UserIdFirestore(value: "user_id_$i"),

--- a/test/services/database/mock_post_data.dart
+++ b/test/services/database/mock_post_data.dart
@@ -6,7 +6,7 @@ import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/database/post/post_location_firestore.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
 
-class MockFirestorePost {
+class MockPostFirestore {
   PostFirestore createPostAt(
     PostData data,
     GeoPoint location, {

--- a/test/services/database/mock_post_repository_service.dart
+++ b/test/services/database/mock_post_repository_service.dart
@@ -1,0 +1,60 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mockito/mockito.dart";
+import "package:proxima/models/database/post/post_data.dart";
+import "package:proxima/models/database/post/post_firestore.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/models/database/post/post_location_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/services/database/post_repository_service.dart";
+
+/// Not a coherent representation of a [PostFirestore]
+/// This is just here as a placeholder value that will be overridden in the tests
+final _mockEmptyFirestorePost = PostFirestore(
+  id: const PostIdFirestore(value: ""),
+  location: const PostLocationFirestore(
+    geoPoint: GeoPoint(0, 0),
+    geohash: "",
+  ),
+  data: PostData(
+    ownerId: const UserIdFirestore(value: ""),
+    title: "",
+    description: "",
+    publicationTime: Timestamp.fromMillisecondsSinceEpoch(0),
+    voteScore: 0,
+  ),
+);
+
+class MockPostRepositoryService extends Mock implements PostRepositoryService {
+  @override
+  Future<void> addPost(PostData postData, GeoPoint position) {
+    return super.noSuchMethod(
+      Invocation.method(#addPost, [postData, position]),
+      returnValue: Future.value(),
+    );
+  }
+
+  @override
+  Future<void> deletePost(PostIdFirestore postId) {
+    return super.noSuchMethod(
+      Invocation.method(#deletePost, [postId]),
+      returnValue: Future.value(),
+    );
+  }
+
+  @override
+  Future<PostFirestore> getPost(PostIdFirestore postId) {
+    return super.noSuchMethod(
+      Invocation.method(#getPost, [postId]),
+      returnValue: Future.value(_mockEmptyFirestorePost),
+    );
+  }
+
+  @override
+  Future<List<PostFirestore>> getNearPosts(GeoPoint point, double radius) {
+    return super.noSuchMethod(
+      Invocation.method(#getNearPosts, [point, radius]),
+      returnValue: Future.value(List<PostFirestore>.empty()),
+    );
+  }
+}

--- a/test/services/database/mock_user_repository_service.dart
+++ b/test/services/database/mock_user_repository_service.dart
@@ -1,0 +1,43 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:mockito/mockito.dart";
+import "package:proxima/models/database/user/user_data.dart";
+import "package:proxima/models/database/user/user_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/services/database/user_repository_service.dart";
+
+/// Not a coherent representation of a [UserFirestore]
+/// This is just here as a placeholder value that will be overridden in the tests
+final _mockEmptyFirestoreUser = UserFirestore(
+  data: UserData(
+    displayName: "",
+    username: "",
+    joinTime: Timestamp.fromMillisecondsSinceEpoch(0),
+  ),
+  uid: const UserIdFirestore(value: ""),
+);
+
+class MockUserRepositoryService extends Mock implements UserRepositoryService {
+  @override
+  Future<UserFirestore> getUser(UserIdFirestore uid) {
+    return super.noSuchMethod(
+      Invocation.method(#getUser, [uid]),
+      returnValue: Future.value(_mockEmptyFirestoreUser),
+    );
+  }
+
+  @override
+  Future<void> setUser(UserIdFirestore uid, UserData userData) {
+    return super.noSuchMethod(
+      Invocation.method(#setUser, [uid, userData]),
+      returnValue: Future.value(),
+    );
+  }
+
+  @override
+  Future<bool> doesUserExist(UserIdFirestore uid) {
+    return super.noSuchMethod(
+      Invocation.method(#doesUserExist, [uid]),
+      returnValue: Future.value(false),
+    );
+  }
+}

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -15,7 +15,6 @@ void main() {
   group("Post Repository testing", () {
     late FakeFirebaseFirestore firestore;
     late PostRepositoryService postRepository;
-    late MockPostFirestore mockPostFirstore;
 
     const kmRadius = 0.1;
 
@@ -46,7 +45,6 @@ void main() {
       postRepository = PostRepositoryService(
         firestore: firestore,
       );
-      mockPostFirstore = MockPostFirestore();
     });
 
     final post = PostFirestore(
@@ -93,8 +91,8 @@ void main() {
       const userPosition = GeoPoint(40, 20);
       const postPoint = GeoPoint(40.0001, 20.0001); // 14m away
 
-      final postData = mockPostFirstore.generatePostData(1).first;
-      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
+      final postData = MockPostFirestore.generatePostData(1).first;
+      final expectedPost = MockPostFirestore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -108,8 +106,8 @@ void main() {
 
       const postPoint = GeoPoint(40.001, 20.001); // about 140m away
 
-      final postData = mockPostFirstore.generatePostData(1).first;
-      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
+      final postData = MockPostFirestore.generatePostData(1).first;
+      final expectedPost = MockPostFirestore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -125,8 +123,8 @@ void main() {
         52.001188563379976 - 1e-5,
       ); // just below 100m away
 
-      final postData = mockPostFirstore.generatePostData(1).first;
-      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
+      final postData = MockPostFirestore.generatePostData(1).first;
+      final expectedPost = MockPostFirestore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -142,8 +140,8 @@ void main() {
         52.001188563379976 + 1e-5,
       ); // just above 100m away
 
-      final postData = mockPostFirstore.generatePostData(1).first;
-      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
+      final postData = MockPostFirestore.generatePostData(1).first;
+      final expectedPost = MockPostFirestore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -157,7 +155,7 @@ void main() {
       final userGeoFirePoint =
           GeoFirePoint(userPosition.latitude, userPosition.longitude);
 
-      final postData = mockPostFirstore.generatePostData(1).first;
+      final postData = MockPostFirestore.generatePostData(1).first;
 
       await postRepository.addPost(postData, userPosition);
 
@@ -186,10 +184,10 @@ void main() {
         return GeoPoint(40.0001 + i * 0.0001, 20.0001 + i * 0.0001);
       });
 
-      final postsData = mockPostFirstore.generatePostData(nbPosts);
+      final postsData = MockPostFirestore.generatePostData(nbPosts);
 
       final allPosts = List.generate(nbPosts, (i) {
-        return mockPostFirstore.createPostAt(
+        return MockPostFirestore.createPostAt(
           postsData[i],
           pointList[i],
           id: "post_$i",

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -9,7 +9,7 @@ import "package:proxima/models/database/post/post_location_firestore.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
 import "package:proxima/services/database/post_repository_service.dart";
 
-import "mock_post_data.dart";
+import "../../models/database/post/mock_post_data.dart";
 
 void main() {
   group("Post Repository testing", () {

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -15,7 +15,7 @@ void main() {
   group("Post Repository testing", () {
     late FakeFirebaseFirestore firestore;
     late PostRepositoryService postRepository;
-    late MockFirestorePost mockFirestorePost;
+    late MockPostFirestore mockPostFirstore;
 
     const kmRadius = 0.1;
 
@@ -46,7 +46,7 @@ void main() {
       postRepository = PostRepositoryService(
         firestore: firestore,
       );
-      mockFirestorePost = MockFirestorePost();
+      mockPostFirstore = MockPostFirestore();
     });
 
     final post = PostFirestore(
@@ -93,8 +93,8 @@ void main() {
       const userPosition = GeoPoint(40, 20);
       const postPoint = GeoPoint(40.0001, 20.0001); // 14m away
 
-      final postData = mockFirestorePost.generatePostData(1).first;
-      final expectedPost = mockFirestorePost.createPostAt(postData, postPoint);
+      final postData = mockPostFirstore.generatePostData(1).first;
+      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -108,8 +108,8 @@ void main() {
 
       const postPoint = GeoPoint(40.001, 20.001); // about 140m away
 
-      final postData = mockFirestorePost.generatePostData(1).first;
-      final expectedPost = mockFirestorePost.createPostAt(postData, postPoint);
+      final postData = mockPostFirstore.generatePostData(1).first;
+      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -125,8 +125,8 @@ void main() {
         52.001188563379976 - 1e-5,
       ); // just below 100m away
 
-      final postData = mockFirestorePost.generatePostData(1).first;
-      final expectedPost = mockFirestorePost.createPostAt(postData, postPoint);
+      final postData = mockPostFirstore.generatePostData(1).first;
+      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -142,8 +142,8 @@ void main() {
         52.001188563379976 + 1e-5,
       ); // just above 100m away
 
-      final postData = mockFirestorePost.generatePostData(1).first;
-      final expectedPost = mockFirestorePost.createPostAt(postData, postPoint);
+      final postData = mockPostFirstore.generatePostData(1).first;
+      final expectedPost = mockPostFirstore.createPostAt(postData, postPoint);
 
       await setPostFirestore(expectedPost);
 
@@ -157,7 +157,7 @@ void main() {
       final userGeoFirePoint =
           GeoFirePoint(userPosition.latitude, userPosition.longitude);
 
-      final postData = mockFirestorePost.generatePostData(1).first;
+      final postData = mockPostFirstore.generatePostData(1).first;
 
       await postRepository.addPost(postData, userPosition);
 
@@ -186,10 +186,10 @@ void main() {
         return GeoPoint(40.0001 + i * 0.0001, 20.0001 + i * 0.0001);
       });
 
-      final postsData = mockFirestorePost.generatePostData(nbPosts);
+      final postsData = mockPostFirstore.generatePostData(nbPosts);
 
       final allPosts = List.generate(nbPosts, (i) {
-        return mockFirestorePost.createPostAt(
+        return mockPostFirstore.createPostAt(
           postsData[i],
           pointList[i],
           id: "post_$i",


### PR DESCRIPTION
Hello,
This pull request aims to provide the boiler plate code needed to mock the methods of the repositories.
This code is contained in the classes `MockPostRepositoryService` and `MockUserRepositoryService`.

Here is an example of how such a class can be used in a test to mock a repository method
```dart
late MockPostRepositoryService postRepository;

setUp(() {
  // Initialize the mock
  postRepository = MockPostRepositoryService();
});

test("some test", () {
  final point = ...
  final kmPostRadius = ...

  // To mock the [getNearPosts] method when it is called with particular parameters
   when(postRepository.getNearPosts(point, kmPostRadius)).thenAnswer(
        // Here, it is mocked to return an empty list
        (_) async => [], 
   );

  // From this point on, when the "postRepository.getNearPosts(point, kmPostRadius)" is called, the mock overrides
  // enters into action and an empty list will be returned
});


```


This PR also provides a class to easily generate mock data for `UserFirestore` which can be useful when testing.
This class is `MockUserFirestore` located under `test/models/database/user`.

Finally, `MockFirestorePost` has been renamed to `MockPostFirestore` as well as being moved to `test/models/database/user` for consistency.

### Important note:
For the mock of the repositories, the way the code is written can misleadingly make believe that a particular value will be returned whithout having to mock it in the tests with `when(...) ...`.
This, is not the case, if a method from the mock repository is called without having properly set up the `when(...) ...` before, an exception will be thrown.

For example, in the `MockUserRepositoryService`, we have the following override:
```dart
  @override
  Future<bool> doesUserExist(UserIdFirestore uid) {
    return super.noSuchMethod(
      Invocation.method(#doesUserExist, [uid]),
      returnValue: Future.value(false),
    );
  }
```

In our test code we could be tempted to simply call:
```dart
userRepository.doesUserExist(...);
```
expecting it to return it `false`.

This wont work and will throw an exception.
The correct way is:
```dart
when(userRepository.doesUserExist(...)).thenAnswer(
  () async {return false;}
);

userRepository.doesUserExist(...);
```

