### PR TITLE
Fix circular value + Error message in overview

### DIFF
--- a/lib/utils/ui/circular_value.dart
+++ b/lib/utils/ui/circular_value.dart
@@ -18,10 +18,8 @@ class CircularValue<T> extends StatelessWidget {
     return value.maybeWhen(
       data: (data) => builder(context, data),
       orElse: () {
-        return const Expanded(
-          child: Center(
-            child: CircularProgressIndicator(),
-          ),
+        return const Center(
+          child: CircularProgressIndicator(),
         );
       },
     );

--- a/lib/views/home_content/feed/post_feed.dart
+++ b/lib/views/home_content/feed/post_feed.dart
@@ -1,7 +1,6 @@
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/ui/post_overview.dart";
-import "package:proxima/utils/ui/circular_value.dart";
 import "package:proxima/viewmodels/home_view_model.dart";
 import "package:proxima/views/home_content/feed/post_card/post_card.dart";
 import "package:proxima/views/navigation/routes.dart";
@@ -63,9 +62,8 @@ class PostFeed extends HookConsumerWidget {
           key: feedSortOptionKey,
         ),
         const Divider(),
-        CircularValue(
-          value: asyncPosts,
-          builder: (context, posts) {
+        asyncPosts.when(
+          data: (posts) {
             final postsList = PostList(
               posts: posts,
               onRefresh: () async {
@@ -75,6 +73,25 @@ class PostFeed extends HookConsumerWidget {
 
             return Expanded(
               child: posts.isEmpty ? emptyHelper : postsList,
+            );
+          },
+          loading: () {
+            return const Expanded(
+              child: Center(
+                child: CircularProgressIndicator(),
+              ),
+            );
+          },
+          error: (error, _) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text("An error occurred"),
+                  const SizedBox(height: 10),
+                  refreshButton,
+                ],
+              ),
             );
           },
         ),

--- a/lib/views/home_content/feed/post_feed.dart
+++ b/lib/views/home_content/feed/post_feed.dart
@@ -83,14 +83,16 @@ class PostFeed extends HookConsumerWidget {
             );
           },
           error: (error, _) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text("An error occurred"),
-                  const SizedBox(height: 10),
-                  refreshButton,
-                ],
+            return Expanded(
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Text("An error occurred"),
+                    const SizedBox(height: 10),
+                    refreshButton,
+                  ],
+                ),
               ),
             );
           },


### PR DESCRIPTION
Hello,
This PR aims to fix the CircularValue widget that was wrapping it's `CircularProgressIndicator` leading to some crashes when the `CircularValue` was not integrated in a compatible parent widget.

Because of this fix, the overview is also modified to keep the `CircularProgressIndicator` centered.
This refactoring also allowed for the possibility of displaying an error message in the case where there was an error fetching the nearby posts.
Thus with this PR, if the nearby posts failed to be fetched, the error message `An error occurred` will be displayed in the overview together with a button that allows the user to refresh (retry to fetch the nearby posts).

