### PR TITLE
Add content permissions to release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@ name: Flutter Application GitHub Release
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+
 jobs:
   proxima-app-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just a small PR to make the release action have the correct permissions work.
Currently the action fails with 403 errors.

![image](https://github.com/ProximaEPFL/proxima/assets/82676334/24a1fb0d-3105-460f-a647-7fa464b33389)

gh release needs this write permission. See Permissions in https://github.com/softprops/action-gh-release.

I have not found a way of testing this github action and plan on merging changes into main until it works. I know that @gruvw tested his pr #80 on a fork of the repo, but that still did not show the problem. Act is not useful either because this action needs access to a github repo and releases. If you have other ideas to test the workflow first I would be happy to know, otherwise we will just merge changes until it works.
