### PR TITLE
fix: "Challenges" instead of "Your Challenges" to avoid overflow

### DIFF
--- a/lib/views/navigation/bottom_navigation_bar/navigation_bar_routes.dart
+++ b/lib/views/navigation/bottom_navigation_bar/navigation_bar_routes.dart
@@ -49,7 +49,7 @@ enum NavigationbarRoutes {
   String pageLabel() {
     switch (this) {
       case challenge:
-        return "Your challenges";
+        return "Challenges";
       case _:
         return defaultLabelText;
     }


### PR DESCRIPTION
This PR fixes #110, by replacing "Your Challenges" by "Challenges" to avoid an overflow or having to crop the text