### PR TITLE
Fix duplicate key string in profile testing

### DIFF
--- a/lib/views/pages/profile/posts_info/info_card_badge.dart
+++ b/lib/views/pages/profile/posts_info/info_card_badge.dart
@@ -2,7 +2,7 @@ import "package:flutter/material.dart";
 
 //info card for the badges
 class InfoCardBadge extends StatelessWidget {
-  static const cardKey = Key("card");
+  static const infoCardBadgeKey = Key("infoCardBadge");
 
   const InfoCardBadge({
     super.key,
@@ -14,7 +14,7 @@ class InfoCardBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      key: cardKey,
+      key: infoCardBadgeKey,
       width: 54,
       height: 80,
       decoration: BoxDecoration(

--- a/lib/views/pages/profile/posts_info/info_card_comment.dart
+++ b/lib/views/pages/profile/posts_info/info_card_comment.dart
@@ -2,7 +2,7 @@ import "package:flutter/material.dart";
 
 //info card for the comments
 class InfoCardComment extends StatelessWidget {
-  static const cardKey = Key("card");
+  static const infoCardCommentKey = Key("infoCardComment");
 
   const InfoCardComment({
     super.key,
@@ -16,7 +16,7 @@ class InfoCardComment extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      key: cardKey,
+      key: infoCardCommentKey,
       width: 54,
       height: 80,
       decoration: BoxDecoration(

--- a/lib/views/pages/profile/posts_info/info_card_post.dart
+++ b/lib/views/pages/profile/posts_info/info_card_post.dart
@@ -2,7 +2,7 @@ import "package:flutter/material.dart";
 
 //info card for the posts
 class InfoCardPost extends StatelessWidget {
-  static const cardKey = Key("card");
+  static const infoCardPostKey = Key("infoCardPost");
 
   const InfoCardPost({
     super.key,
@@ -18,7 +18,7 @@ class InfoCardPost extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      key: cardKey,
+      key: infoCardPostKey,
       width: 54,
       height: 80,
       decoration: BoxDecoration(

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -73,14 +73,12 @@ void main() {
     await tester.pumpAndSettle();
 
     // Check that badges are displayed
-    final badgeCard = find.byKey(InfoCardBadge.cardKey);
+    final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
     expect(badgeCard, findsWidgets);
 
-    final postCard = find.byKey(InfoCardPost.cardKey);
+    //Check that the post card is displayed
+    final postCard = find.byKey(InfoCardPost.infoCardPostKey);
     expect(postCard, findsWidgets);
-
-    final commentCard = find.byKey(InfoCardComment.cardKey);
-    expect(commentCard, findsWidgets);
 
     // Check that the info column is displayed
     final infoColumn = find.byKey(ProfilePage.postColumnKey);

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -8,7 +8,6 @@ import "package:proxima/views/navigation/routes.dart";
 import "package:proxima/views/pages/home/home_page.dart";
 import "package:proxima/views/pages/home/top_bar/app_top_bar.dart";
 import "package:proxima/views/pages/profile/posts_info/info_card_badge.dart";
-import "package:proxima/views/pages/profile/posts_info/info_card_comment.dart";
 import "package:proxima/views/pages/profile/posts_info/info_card_post.dart";
 import "package:proxima/views/pages/profile/posts_info/info_row.dart";
 import "package:proxima/views/pages/profile/profile_page.dart";


### PR DESCRIPTION
This PR rename key string on the badge, post and comment card. 
These widget used the same key string, which cause a test on the profile passing when the test shouldn't.