### PR TITLE
Make user and post mock arguments nullable

### DIFF
--- a/test/services/database/mock_post_repository_service.dart
+++ b/test/services/database/mock_post_repository_service.dart
@@ -35,7 +35,7 @@ class MockPostRepositoryService extends Mock implements PostRepositoryService {
   }
 
   @override
-  Future<void> deletePost(PostIdFirestore postId) {
+  Future<void> deletePost(PostIdFirestore? postId) {
     return super.noSuchMethod(
       Invocation.method(#deletePost, [postId]),
       returnValue: Future.value(),
@@ -43,7 +43,7 @@ class MockPostRepositoryService extends Mock implements PostRepositoryService {
   }
 
   @override
-  Future<PostFirestore> getPost(PostIdFirestore postId) {
+  Future<PostFirestore> getPost(PostIdFirestore? postId) {
     return super.noSuchMethod(
       Invocation.method(#getPost, [postId]),
       returnValue: Future.value(_mockEmptyFirestorePost),
@@ -51,7 +51,7 @@ class MockPostRepositoryService extends Mock implements PostRepositoryService {
   }
 
   @override
-  Future<List<PostFirestore>> getNearPosts(GeoPoint point, double radius) {
+  Future<List<PostFirestore>> getNearPosts(GeoPoint? point, double? radius) {
     return super.noSuchMethod(
       Invocation.method(#getNearPosts, [point, radius]),
       returnValue: Future.value(List<PostFirestore>.empty()),

--- a/test/services/database/mock_user_repository_service.dart
+++ b/test/services/database/mock_user_repository_service.dart
@@ -18,7 +18,7 @@ final _mockEmptyFirestoreUser = UserFirestore(
 
 class MockUserRepositoryService extends Mock implements UserRepositoryService {
   @override
-  Future<UserFirestore> getUser(UserIdFirestore uid) {
+  Future<UserFirestore> getUser(UserIdFirestore? uid) {
     return super.noSuchMethod(
       Invocation.method(#getUser, [uid]),
       returnValue: Future.value(_mockEmptyFirestoreUser),
@@ -26,7 +26,7 @@ class MockUserRepositoryService extends Mock implements UserRepositoryService {
   }
 
   @override
-  Future<void> setUser(UserIdFirestore uid, UserData userData) {
+  Future<void> setUser(UserIdFirestore? uid, UserData? userData) {
     return super.noSuchMethod(
       Invocation.method(#setUser, [uid, userData]),
       returnValue: Future.value(),
@@ -34,7 +34,7 @@ class MockUserRepositoryService extends Mock implements UserRepositoryService {
   }
 
   @override
-  Future<bool> doesUserExist(UserIdFirestore uid) {
+  Future<bool> doesUserExist(UserIdFirestore? uid) {
     return super.noSuchMethod(
       Invocation.method(#doesUserExist, [uid]),
       returnValue: Future.value(false),


### PR DESCRIPTION
When writing other tests, I found that the arguments for the methods of the mocks needed to be nullable in order to use matchers like any or captureAny. You can find more information [here](https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md#manually-override-a-method-with-a-non-nullable-parameter-type).

This short PR fixes this problem for the current mocks defined in the code. Please tell me if you found something I missed.