### PR TITLE
Profile post and comment popup in user profile page

### DIFF
--- a/lib/views/pages/profile/posts_info/info_card_comment.dart
+++ b/lib/views/pages/profile/posts_info/info_card_comment.dart
@@ -1,8 +1,11 @@
 import "package:flutter/material.dart";
+import "package:proxima/views/pages/profile/posts_info/popup/comment_popup.dart";
 
 //info card for the comments
 class InfoCardComment extends StatelessWidget {
   static const cardKey = Key("card");
+
+  static const borderRadius = BorderRadius.all(Radius.circular(10));
 
   const InfoCardComment({
     super.key,
@@ -21,24 +24,37 @@ class InfoCardComment extends StatelessWidget {
       height: 80,
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.secondaryContainer,
-        borderRadius: const BorderRadius.all(Radius.circular(10)),
+        borderRadius: borderRadius,
         boxShadow: [shadow],
       ),
-      child: Center(
-        child: ListTile(
-          title: Text(
-            comment,
-            maxLines: 3,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.bodySmall,
+      child: Material(
+        clipBehavior: Clip.hardEdge,
+        borderRadius: borderRadius,
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () => showDialog<void>(
+            context: context,
+            builder: (BuildContext context) {
+              return CommentPopUp(comment: comment);
+            },
           ),
-          trailing: const IconButton(
-            icon: Icon(
-              Icons.delete,
-              size: 32,
+          child: Center(
+            child: ListTile(
+              title: Text(
+                comment,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              trailing: const IconButton(
+                icon: Icon(
+                  Icons.delete,
+                  size: 32,
+                ),
+                //TODO: add the delete function
+                onPressed: null,
+              ),
             ),
-            //TODO: add the delete function
-            onPressed: null,
           ),
         ),
       ),

--- a/lib/views/pages/profile/posts_info/info_card_post.dart
+++ b/lib/views/pages/profile/posts_info/info_card_post.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:proxima/views/pages/profile/posts_info/popup/post_popup.dart";
 
 //info card for the posts
 class InfoCardPost extends StatelessWidget {
@@ -61,31 +62,6 @@ class InfoCardPost extends StatelessWidget {
               ),
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class PostPopUp extends StatelessWidget {
-  const PostPopUp({
-    super.key,
-    required this.title,
-    required this.description,
-  });
-
-  final String title;
-  final String description;
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(title),
-      content: SingleChildScrollView(
-        child: ListBody(
-          children: <Widget>[
-            Text(description),
-          ],
         ),
       ),
     );

--- a/lib/views/pages/profile/posts_info/info_card_post.dart
+++ b/lib/views/pages/profile/posts_info/info_card_post.dart
@@ -33,7 +33,12 @@ class InfoCardPost extends StatelessWidget {
         borderRadius: borderRadius,
         color: Colors.transparent,
         child: InkWell(
-          onTap: () => {},
+          onTap: () => showDialog<void>(
+            context: context,
+            builder: (BuildContext context) {
+              return PostPopUp(title: title, description: description);
+            },
+          ),
           child: Center(
             child: ListTile(
               title: Text(
@@ -56,6 +61,31 @@ class InfoCardPost extends StatelessWidget {
               ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class PostPopUp extends StatelessWidget {
+  const PostPopUp({
+    super.key,
+    required this.title,
+    required this.description,
+  });
+
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: <Widget>[
+            Text(description),
+          ],
         ),
       ),
     );

--- a/lib/views/pages/profile/posts_info/info_card_post.dart
+++ b/lib/views/pages/profile/posts_info/info_card_post.dart
@@ -4,6 +4,8 @@ import "package:flutter/material.dart";
 class InfoCardPost extends StatelessWidget {
   static const cardKey = Key("card");
 
+  static const borderRadius = BorderRadius.all(Radius.circular(10));
+
   const InfoCardPost({
     super.key,
     required this.shadow,
@@ -23,28 +25,36 @@ class InfoCardPost extends StatelessWidget {
       height: 80,
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.secondaryContainer,
-        borderRadius: const BorderRadius.all(Radius.circular(10)),
+        borderRadius: borderRadius,
         boxShadow: [shadow],
       ),
-      child: Center(
-        child: ListTile(
-          title: Text(
-            title,
-            style: Theme.of(context).textTheme.titleSmall,
-          ),
-          subtitle: Text(
-            description,
-            style: Theme.of(context).textTheme.bodySmall,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-          trailing: const IconButton(
-            icon: Icon(
-              Icons.delete,
-              size: 32,
+      child: Material(
+        clipBehavior: Clip.hardEdge,
+        borderRadius: borderRadius,
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () => {},
+          child: Center(
+            child: ListTile(
+              title: Text(
+                title,
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              subtitle: Text(
+                description,
+                style: Theme.of(context).textTheme.bodySmall,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              trailing: IconButton(
+                icon: const Icon(
+                  Icons.delete,
+                  size: 32,
+                ),
+                // TODO : add the logic for deleting a post
+                onPressed: () {},
+              ),
             ),
-            // TODO : add the logic for deleting a post
-            onPressed: null,
           ),
         ),
       ),

--- a/lib/views/pages/profile/posts_info/info_card_post.dart
+++ b/lib/views/pages/profile/posts_info/info_card_post.dart
@@ -44,6 +44,8 @@ class InfoCardPost extends StatelessWidget {
             child: ListTile(
               title: Text(
                 title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.titleSmall,
               ),
               subtitle: Text(

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -14,7 +14,9 @@ class CommentPopUp extends StatelessWidget {
       content: Text(comment),
       actions: <Widget>[
         IconButton(
-          onPressed: () {},
+          onPressed: () {
+            Navigator.pop(context);
+          },
           icon: const Icon(Icons.delete),
         ),
       ],

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -1,0 +1,23 @@
+import "package:flutter/material.dart";
+
+class CommentPopUp extends StatelessWidget {
+  const CommentPopUp({
+    super.key,
+    required this.comment,
+  });
+
+  final String comment;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Text(comment),
+      actions: <Widget>[
+        IconButton(
+          onPressed: () {},
+          icon: const Icon(Icons.delete),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -22,9 +22,12 @@ class CommentPopUp extends StatelessWidget {
       content: Scrollbar(
         thumbVisibility: true,
         child: SingleChildScrollView(
-          child: Text(
-            key: commentPopUpDescriptionKey,
-            comment,
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              key: commentPopUpDescriptionKey,
+              comment,
+            ),
           ),
         ),
       ),

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -18,13 +18,25 @@ class CommentPopUp extends StatelessWidget {
         thumbVisibility: true,
         child: SingleChildScrollView(
           child: Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.only(
+              top: 8.0,
+              right: 8.0,
+              bottom: 0.0,
+              left: 8.0,
+            ),
             child: Text(
               key: commentPopUpDescriptionKey,
               comment,
             ),
           ),
         ),
+      ),
+      contentPadding: const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 0.0),
+      actionsPadding: const EdgeInsets.only(
+        right: 24.0,
+        bottom: 12.0,
+        top: 0.0,
+        left: 24.0,
       ),
       actions: <Widget>[
         IconButton(

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -1,6 +1,10 @@
 import "package:flutter/material.dart";
 
 class CommentPopUp extends StatelessWidget {
+  static const commentPopUpTitleKey = Key("commentPopUpTitle");
+  static const commentPopUpDescriptionKey = Key("commentPopUpDescription");
+  static const commentPopUpDeleteButtonKey = Key("commentPopUpDeleteButton");
+
   const CommentPopUp({
     super.key,
     required this.comment,
@@ -11,10 +15,17 @@ class CommentPopUp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text("Comment"),
-      content: Text(comment),
+      title: const Text(
+        key: commentPopUpTitleKey,
+        "Comment",
+      ),
+      content: Text(
+        key: commentPopUpDescriptionKey,
+        comment,
+      ),
       actions: <Widget>[
         IconButton(
+          key: commentPopUpDeleteButtonKey,
           onPressed: () {
             Navigator.pop(context);
           },

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -27,6 +27,7 @@ class CommentPopUp extends StatelessWidget {
         IconButton(
           key: commentPopUpDeleteButtonKey,
           onPressed: () {
+            //TODO: Handle delete comment
             Navigator.pop(context);
           },
           icon: const Icon(Icons.delete),

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -19,9 +19,14 @@ class CommentPopUp extends StatelessWidget {
         key: commentPopUpTitleKey,
         "Comment",
       ),
-      content: Text(
-        key: commentPopUpDescriptionKey,
-        comment,
+      content: Scrollbar(
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          child: Text(
+            key: commentPopUpDescriptionKey,
+            comment,
+          ),
+        ),
       ),
       actions: <Widget>[
         IconButton(

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -1,7 +1,6 @@
 import "package:flutter/material.dart";
 
 class CommentPopUp extends StatelessWidget {
-  static const commentPopUpTitleKey = Key("commentPopUpTitle");
   static const commentPopUpDescriptionKey = Key("commentPopUpDescription");
   static const commentPopUpDeleteButtonKey = Key("commentPopUpDeleteButton");
 
@@ -15,10 +14,6 @@ class CommentPopUp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text(
-        key: commentPopUpTitleKey,
-        "Comment",
-      ),
       content: Scrollbar(
         thumbVisibility: true,
         child: SingleChildScrollView(

--- a/lib/views/pages/profile/posts_info/popup/comment_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/comment_popup.dart
@@ -11,6 +11,7 @@ class CommentPopUp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      title: const Text("Comment"),
       content: Text(comment),
       actions: <Widget>[
         IconButton(

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -1,6 +1,10 @@
 import "package:flutter/material.dart";
 
 class PostPopUp extends StatelessWidget {
+  static const postPopUpTitleKey = Key("postPopUpTitle");
+  static const postPopUpDescriptionKey = Key("postPopUpDescription");
+  static const postPopUpDeleteButtonKey = Key("postPopUpDeleteButton");
+
   const PostPopUp({
     super.key,
     required this.title,
@@ -13,10 +17,17 @@ class PostPopUp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text(title),
-      content: Text(description),
+      title: Text(
+        key: postPopUpTitleKey,
+        title,
+      ),
+      content: Text(
+        key: postPopUpDescriptionKey,
+        description,
+      ),
       actions: <Widget>[
         IconButton(
+          key: postPopUpDeleteButtonKey,
           onPressed: () {
             Navigator.pop(context);
           },

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -29,6 +29,7 @@ class PostPopUp extends StatelessWidget {
         IconButton(
           key: postPopUpDeleteButtonKey,
           onPressed: () {
+            //TODO: Handle delete post
             Navigator.pop(context);
           },
           icon: const Icon(Icons.delete),

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -17,9 +17,13 @@ class PostPopUp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text(
-        key: postPopUpTitleKey,
-        title,
+      title: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Text(
+          key: postPopUpTitleKey,
+          maxLines: 1,
+          title,
+        ),
       ),
       content: Scrollbar(
         thumbVisibility: true,

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -24,9 +24,12 @@ class PostPopUp extends StatelessWidget {
       content: Scrollbar(
         thumbVisibility: true,
         child: SingleChildScrollView(
-          child: Text(
-            key: postPopUpDescriptionKey,
-            description,
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              key: postPopUpDescriptionKey,
+              description,
+            ),
           ),
         ),
       ),

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -42,7 +42,7 @@ class PostPopUp extends StatelessWidget {
           ),
         ),
       ),
-      contentPadding: const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 0.0),
+      contentPadding: const EdgeInsets.fromLTRB(24.0, 8.0, 24.0, 0.0),
       actionsPadding: const EdgeInsets.only(
         right: 24.0,
         bottom: 12.0,

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -1,0 +1,26 @@
+import "package:flutter/material.dart";
+
+class PostPopUp extends StatelessWidget {
+  const PostPopUp({
+    super.key,
+    required this.title,
+    required this.description,
+  });
+
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(description),
+      actions: <Widget>[
+        IconButton(
+          onPressed: () {},
+          icon: const Icon(Icons.delete),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -17,7 +17,9 @@ class PostPopUp extends StatelessWidget {
       content: Text(description),
       actions: <Widget>[
         IconButton(
-          onPressed: () {},
+          onPressed: () {
+            Navigator.pop(context);
+          },
           icon: const Icon(Icons.delete),
         ),
       ],

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -29,13 +29,25 @@ class PostPopUp extends StatelessWidget {
         thumbVisibility: true,
         child: SingleChildScrollView(
           child: Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.only(
+              top: 8.0,
+              right: 8.0,
+              bottom: 0.0,
+              left: 8.0,
+            ),
             child: Text(
               key: postPopUpDescriptionKey,
               description,
             ),
           ),
         ),
+      ),
+      contentPadding: const EdgeInsets.fromLTRB(24.0, 20.0, 24.0, 0.0),
+      actionsPadding: const EdgeInsets.only(
+        right: 24.0,
+        bottom: 12.0,
+        top: 0.0,
+        left: 24.0,
       ),
       actions: <Widget>[
         IconButton(

--- a/lib/views/pages/profile/posts_info/popup/post_popup.dart
+++ b/lib/views/pages/profile/posts_info/popup/post_popup.dart
@@ -21,9 +21,14 @@ class PostPopUp extends StatelessWidget {
         key: postPopUpTitleKey,
         title,
       ),
-      content: Text(
-        key: postPopUpDescriptionKey,
-        description,
+      content: Scrollbar(
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          child: Text(
+            key: postPopUpDescriptionKey,
+            description,
+          ),
+        ),
       ),
       actions: <Widget>[
         IconButton(

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -191,10 +191,6 @@ void main() {
         final commentPopup = find.byType(CommentPopUp);
         expect(commentPopup, findsOneWidget);
 
-        //Check that the title of the pop up is displayed
-        final commentPopupTitle = find.byKey(CommentPopUp.commentPopUpTitleKey);
-        expect(commentPopupTitle, findsOneWidget);
-
         //Check that the description of the pop up is displayed
         final commentPopupDescription =
             find.byKey(CommentPopUp.commentPopUpDescriptionKey);

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -74,7 +74,7 @@ void main() {
       );
     }
 
-    Future<void> commonSetup(WidgetTester tester) async {
+    testWidgets("Various widget are displayed", (tester) async {
       await tester.pumpWidget(getMockedProxima());
       await tester.pumpAndSettle();
 
@@ -89,10 +89,6 @@ void main() {
       // Check that the comment tab is displayed
       final commentTab = find.byKey(ProfilePage.commentTabKey);
       expect(commentTab, findsOneWidget);
-    }
-
-    testWidgets("Various widget are displayed", (tester) async {
-      await commonSetup(tester);
 
       // Check that badges are displayed
       final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
@@ -123,7 +119,6 @@ void main() {
       expect(postColumn, findsOneWidget);
 
       // Tap on the comment tab
-      final commentTab = find.byKey(ProfilePage.commentTabKey);
       await tester.tap(commentTab);
       await tester.pumpAndSettle();
 
@@ -134,7 +129,8 @@ void main() {
 
     group("Popups working as expected", () {
       testWidgets("Post popup working as expected", (tester) async {
-        await commonSetup(tester);
+        await tester.pumpWidget(getMockedProxima());
+        await tester.pumpAndSettle();
 
         //Check tab on the first post
         final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
@@ -172,7 +168,8 @@ void main() {
       });
 
       testWidgets("Comment popup working as expected", (tester) async {
-        await commonSetup(tester);
+        await tester.pumpWidget(getMockedProxima());
+        await tester.pumpAndSettle();
 
         // Tap on the comment tab
         final commentTab = find.byKey(ProfilePage.commentTabKey);

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -165,6 +165,14 @@ void main() {
       final postPopupDeleteButton =
           find.byKey(PostPopUp.postPopUpDeleteButtonKey);
       expect(postPopupDeleteButton, findsOneWidget);
+
+      //Check clicking on the delete button come back to the profile page
+      await tester.tap(postPopupDeleteButton);
+      await tester.pumpAndSettle();
+
+      //Check that the profile page is displayed
+      final profilePage = find.byType(ProfilePage);
+      expect(profilePage, findsOneWidget);
     });
 
     testWidgets("Tab working as expected", (tester) async {
@@ -212,6 +220,14 @@ void main() {
       final commentPopupDeleteButton =
           find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
       expect(commentPopupDeleteButton, findsOneWidget);
+
+      //Check clicking on the delete button come back to the profile page
+      await tester.tap(commentPopupDeleteButton);
+      await tester.pumpAndSettle();
+
+      //Check that the profile page is displayed
+      final profilePage = find.byType(ProfilePage);
+      expect(profilePage, findsOneWidget);
     });
   });
 }

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -52,211 +52,166 @@ void main() {
     final profilePage = find.byType(ProfilePage);
     expect(profilePage, findsOneWidget);
   });
+  group("Profile widget page testing", () {
+    setUp(() async {
+      setupFirebaseAuthMocks();
+    });
 
-  testWidgets("Various widget are displayed", (tester) async {
-    setupFirebaseAuthMocks();
+    ProviderScope getMockedProxima() {
+      MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
 
-    MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
+      final firebaseAuthMocksOverrides = [
+        firebaseAuthProvider.overrideWithValue(auth),
+      ];
 
-    final firebaseAuthMocksOverrides = [
-      firebaseAuthProvider.overrideWithValue(auth),
-    ];
+      return ProviderScope(
+        overrides: firebaseAuthMocksOverrides,
+        child: const MaterialApp(
+          onGenerateRoute: generateRoute,
+          title: "Profile page",
+          home: ProfilePage(),
+        ),
+      );
+    }
 
-    Widget profilePageWidget = ProviderScope(
-      overrides: firebaseAuthMocksOverrides,
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
+    testWidgets("Various widget are displayed", (tester) async {
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
 
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
+      // Check that badges are displayed
+      final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
+      expect(badgeCard, findsWidgets);
 
-    // Check that badges are displayed
-    final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
-    expect(badgeCard, findsWidgets);
+      //Check that the post card is displayed
+      final postCard = find.byKey(InfoCardPost.infoCardPostKey);
+      expect(postCard, findsWidgets);
 
-    //Check that the post card is displayed
-    final postCard = find.byKey(InfoCardPost.infoCardPostKey);
-    expect(postCard, findsWidgets);
+      // Check that the info column is displayed
+      final infoColumn = find.byKey(ProfilePage.postColumnKey);
+      expect(infoColumn, findsOneWidget);
 
-    // Check that the info column is displayed
-    final infoColumn = find.byKey(ProfilePage.postColumnKey);
-    expect(infoColumn, findsOneWidget);
+      // Check that the info row is displayed
+      final infoRowWidget = find.byKey(InfoRow.infoRowKey);
+      expect(infoRowWidget, findsOneWidget);
 
-    // Check that the info row is displayed
-    final infoRowWidget = find.byKey(InfoRow.infoRowKey);
-    expect(infoRowWidget, findsOneWidget);
+      //Check that centauri points are displayed
+      final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
+      expect(centauriPoints, findsOneWidget);
 
-    //Check that centauri points are displayed
-    final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
-    expect(centauriPoints, findsOneWidget);
+      //Check that the user account is displayed
+      final userAccount = find.byKey(UserAccount.userInfoKey);
+      expect(userAccount, findsOneWidget);
 
-    //Check that the user account is displayed
-    final userAccount = find.byKey(UserAccount.userInfoKey);
-    expect(userAccount, findsOneWidget);
+      //Check that the tab is displayed
+      final tab = find.byKey(ProfilePage.tabKey);
+      expect(tab, findsOneWidget);
+    });
 
-    //Check that the tab is displayed
-    final tab = find.byKey(ProfilePage.tabKey);
-    expect(tab, findsOneWidget);
-  });
+    testWidgets("Tab working as expected", (tester) async {
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
 
-  testWidgets("Tab working as expected", (tester) async {
-    setupFirebaseAuthMocks();
+      // Check that the post tab is displayed
+      final postTab = find.byKey(ProfilePage.postTabKey);
+      expect(postTab, findsOneWidget);
 
-    MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
+      // Check that the comment tab is displayed
+      final commentTab = find.byKey(ProfilePage.commentTabKey);
+      expect(commentTab, findsOneWidget);
 
-    final firebaseAuthMocksOverrides = [
-      firebaseAuthProvider.overrideWithValue(auth),
-    ];
+      //Check that post column is displayed
+      final postColumn = find.byKey(ProfilePage.postColumnKey);
+      expect(postColumn, findsOneWidget);
 
-    Widget profilePageWidget = ProviderScope(
-      overrides: firebaseAuthMocksOverrides,
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
+      // Tap on the comment tab
+      await tester.tap(commentTab);
+      await tester.pumpAndSettle();
 
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
+      // Check that the comment column is displayed
+      final commentColumn = find.byKey(ProfilePage.commentColumnKey);
+      expect(commentColumn, findsOneWidget);
+    });
 
-    // Check that the post tab is displayed
-    final postTab = find.byKey(ProfilePage.postTabKey);
-    expect(postTab, findsOneWidget);
+    testWidgets("Post popup working as expected", (tester) async {
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
 
-    // Check that the comment tab is displayed
-    final commentTab = find.byKey(ProfilePage.commentTabKey);
-    expect(commentTab, findsOneWidget);
+      //Check that post column is displayed
+      final postColumn = find.byKey(ProfilePage.postColumnKey);
+      expect(postColumn, findsOneWidget);
 
-    //Check that post column is displayed
-    final postColumn = find.byKey(ProfilePage.postColumnKey);
-    expect(postColumn, findsOneWidget);
+      //Check tab on the first post
+      final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
+      expect(infoCardPost, findsWidgets);
 
-    // Tap on the comment tab
-    await tester.tap(commentTab);
-    await tester.pumpAndSettle();
+      // Tap on the first post
+      await tester.tap(infoCardPost.first);
+      await tester.pumpAndSettle();
 
-    // Check that the comment column is displayed
-    final commentColumn = find.byKey(ProfilePage.commentColumnKey);
-    expect(commentColumn, findsOneWidget);
-  });
+      // Check that the post popup is displayed
+      final postPopup = find.byType(PostPopUp);
+      expect(postPopup, findsOneWidget);
 
-  testWidgets("Post popup working as expected", (tester) async {
-    setupFirebaseAuthMocks();
+      //Check that the title of the pop up is displayed
+      final postPopupTitle = find.byKey(PostPopUp.postPopUpTitleKey);
+      expect(postPopupTitle, findsOneWidget);
 
-    MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
+      //Check that the description of the pop up is displayed
+      final postPopupDescription =
+          find.byKey(PostPopUp.postPopUpDescriptionKey);
+      expect(postPopupDescription, findsOneWidget);
 
-    final firebaseAuthMocksOverrides = [
-      firebaseAuthProvider.overrideWithValue(auth),
-    ];
+      //Check that the delete button is displayed
+      final postPopupDeleteButton =
+          find.byKey(PostPopUp.postPopUpDeleteButtonKey);
+      expect(postPopupDeleteButton, findsOneWidget);
+    });
 
-    Widget profilePageWidget = ProviderScope(
-      overrides: firebaseAuthMocksOverrides,
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
+    testWidgets("Tab working as expected", (tester) async {
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
 
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
+      // Check that the comment tab is displayed
+      final commentTab = find.byKey(ProfilePage.commentTabKey);
+      expect(commentTab, findsOneWidget);
 
-    //Check that post column is displayed
-    final postColumn = find.byKey(ProfilePage.postColumnKey);
-    expect(postColumn, findsOneWidget);
+      //Check that post column is displayed
+      final postColumn = find.byKey(ProfilePage.postColumnKey);
+      expect(postColumn, findsOneWidget);
 
-    //Check tab on the first post
-    final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
-    expect(infoCardPost, findsWidgets);
+      // Tap on the comment tab
+      await tester.tap(commentTab);
+      await tester.pumpAndSettle();
 
-    // Tap on the first post
-    await tester.tap(infoCardPost.first);
-    await tester.pumpAndSettle();
+      // Check that the comment column is displayed
+      final commentColumn = find.byKey(ProfilePage.commentColumnKey);
+      expect(commentColumn, findsOneWidget);
 
-    // Check that the post popup is displayed
-    final postPopup = find.byType(PostPopUp);
-    expect(postPopup, findsOneWidget);
+      //Check tab on the first post
+      final infoCardComment = find.byKey(InfoCardComment.infoCardCommentKey);
+      expect(infoCardComment, findsWidgets);
 
-    //Check that the title of the pop up is displayed
-    final postPopupTitle = find.byKey(PostPopUp.postPopUpTitleKey);
-    expect(postPopupTitle, findsOneWidget);
+      // Tap on the first post
+      await tester.tap(infoCardComment.first);
+      await tester.pumpAndSettle();
 
-    //Check that the description of the pop up is displayed
-    final postPopupDescription = find.byKey(PostPopUp.postPopUpDescriptionKey);
-    expect(postPopupDescription, findsOneWidget);
+      // Check that the comment popup is displayed
+      final commentPopup = find.byType(CommentPopUp);
+      expect(commentPopup, findsOneWidget);
 
-    //Check that the delete button is displayed
-    final postPopupDeleteButton =
-        find.byKey(PostPopUp.postPopUpDeleteButtonKey);
-    expect(postPopupDeleteButton, findsOneWidget);
-  });
+      //Check that the title of the pop up is displayed
+      final commentPopupTitle = find.byKey(CommentPopUp.commentPopUpTitleKey);
+      expect(commentPopupTitle, findsOneWidget);
 
-  testWidgets("Tab working as expected", (tester) async {
-    setupFirebaseAuthMocks();
+      //Check that the description of the pop up is displayed
+      final commentPopupDescription =
+          find.byKey(CommentPopUp.commentPopUpDescriptionKey);
+      expect(commentPopupDescription, findsOneWidget);
 
-    MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
-
-    final firebaseAuthMocksOverrides = [
-      firebaseAuthProvider.overrideWithValue(auth),
-    ];
-
-    Widget profilePageWidget = ProviderScope(
-      overrides: firebaseAuthMocksOverrides,
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
-
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
-
-    // Check that the comment tab is displayed
-    final commentTab = find.byKey(ProfilePage.commentTabKey);
-    expect(commentTab, findsOneWidget);
-
-    //Check that post column is displayed
-    final postColumn = find.byKey(ProfilePage.postColumnKey);
-    expect(postColumn, findsOneWidget);
-
-    // Tap on the comment tab
-    await tester.tap(commentTab);
-    await tester.pumpAndSettle();
-
-    // Check that the comment column is displayed
-    final commentColumn = find.byKey(ProfilePage.commentColumnKey);
-    expect(commentColumn, findsOneWidget);
-
-    //Check tab on the first post
-    final infoCardComment = find.byKey(InfoCardComment.infoCardCommentKey);
-    expect(infoCardComment, findsWidgets);
-
-    // Tap on the first post
-    await tester.tap(infoCardComment.first);
-    await tester.pumpAndSettle();
-
-    // Check that the comment popup is displayed
-    final commentPopup = find.byType(CommentPopUp);
-    expect(commentPopup, findsOneWidget);
-
-    //Check that the title of the pop up is displayed
-    final commentPopupTitle = find.byKey(CommentPopUp.commentPopUpTitleKey);
-    expect(commentPopupTitle, findsOneWidget);
-
-    //Check that the description of the pop up is displayed
-    final commentPopupDescription =
-        find.byKey(CommentPopUp.commentPopUpDescriptionKey);
-    expect(commentPopupDescription, findsOneWidget);
-
-    //Check that the delete button is displayed
-    final commentPopupDeleteButton =
-        find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
-    expect(commentPopupDeleteButton, findsOneWidget);
+      //Check that the delete button is displayed
+      final commentPopupDeleteButton =
+          find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
+      expect(commentPopupDeleteButton, findsOneWidget);
+    });
   });
 }

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -8,8 +8,11 @@ import "package:proxima/views/navigation/routes.dart";
 import "package:proxima/views/pages/home/home_page.dart";
 import "package:proxima/views/pages/home/top_bar/app_top_bar.dart";
 import "package:proxima/views/pages/profile/posts_info/info_card_badge.dart";
+import "package:proxima/views/pages/profile/posts_info/info_card_comment.dart";
 import "package:proxima/views/pages/profile/posts_info/info_card_post.dart";
 import "package:proxima/views/pages/profile/posts_info/info_row.dart";
+import "package:proxima/views/pages/profile/posts_info/popup/comment_popup.dart";
+import "package:proxima/views/pages/profile/posts_info/popup/post_popup.dart";
 import "package:proxima/views/pages/profile/profile_page.dart";
 import "package:proxima/views/pages/profile/user_info/user_account.dart";
 import "../services/firebase/setup_firebase_mocks.dart";
@@ -140,5 +143,120 @@ void main() {
     // Check that the comment column is displayed
     final commentColumn = find.byKey(ProfilePage.commentColumnKey);
     expect(commentColumn, findsOneWidget);
+  });
+
+  testWidgets("Post popup working as expected", (tester) async {
+    setupFirebaseAuthMocks();
+
+    MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
+
+    final firebaseAuthMocksOverrides = [
+      firebaseAuthProvider.overrideWithValue(auth),
+    ];
+
+    Widget profilePageWidget = ProviderScope(
+      overrides: firebaseAuthMocksOverrides,
+      child: const MaterialApp(
+        onGenerateRoute: generateRoute,
+        title: "Profile page",
+        home: ProfilePage(),
+      ),
+    );
+
+    await tester.pumpWidget(profilePageWidget);
+    await tester.pumpAndSettle();
+
+    //Check that post column is displayed
+    final postColumn = find.byKey(ProfilePage.postColumnKey);
+    expect(postColumn, findsOneWidget);
+
+    //Check tab on the first post
+    final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
+    expect(infoCardPost, findsWidgets);
+
+    // Tap on the first post
+    await tester.tap(infoCardPost.first);
+    await tester.pumpAndSettle();
+
+    // Check that the post popup is displayed
+    final postPopup = find.byType(PostPopUp);
+    expect(postPopup, findsOneWidget);
+
+    //Check that the title of the pop up is displayed
+    final postPopupTitle = find.byKey(PostPopUp.postPopUpTitleKey);
+    expect(postPopupTitle, findsOneWidget);
+
+    //Check that the description of the pop up is displayed
+    final postPopupDescription = find.byKey(PostPopUp.postPopUpDescriptionKey);
+    expect(postPopupDescription, findsOneWidget);
+
+    //Check that the delete button is displayed
+    final postPopupDeleteButton =
+        find.byKey(PostPopUp.postPopUpDeleteButtonKey);
+    expect(postPopupDeleteButton, findsOneWidget);
+  });
+
+  testWidgets("Tab working as expected", (tester) async {
+    setupFirebaseAuthMocks();
+
+    MockFirebaseAuth auth = MockFirebaseAuth(signedIn: true);
+
+    final firebaseAuthMocksOverrides = [
+      firebaseAuthProvider.overrideWithValue(auth),
+    ];
+
+    Widget profilePageWidget = ProviderScope(
+      overrides: firebaseAuthMocksOverrides,
+      child: const MaterialApp(
+        onGenerateRoute: generateRoute,
+        title: "Profile page",
+        home: ProfilePage(),
+      ),
+    );
+
+    await tester.pumpWidget(profilePageWidget);
+    await tester.pumpAndSettle();
+
+    // Check that the comment tab is displayed
+    final commentTab = find.byKey(ProfilePage.commentTabKey);
+    expect(commentTab, findsOneWidget);
+
+    //Check that post column is displayed
+    final postColumn = find.byKey(ProfilePage.postColumnKey);
+    expect(postColumn, findsOneWidget);
+
+    // Tap on the comment tab
+    await tester.tap(commentTab);
+    await tester.pumpAndSettle();
+
+    // Check that the comment column is displayed
+    final commentColumn = find.byKey(ProfilePage.commentColumnKey);
+    expect(commentColumn, findsOneWidget);
+
+    //Check tab on the first post
+    final infoCardComment = find.byKey(InfoCardComment.infoCardCommentKey);
+    expect(infoCardComment, findsWidgets);
+
+    // Tap on the first post
+    await tester.tap(infoCardComment.first);
+    await tester.pumpAndSettle();
+
+    // Check that the comment popup is displayed
+    final commentPopup = find.byType(CommentPopUp);
+    expect(commentPopup, findsOneWidget);
+
+    //Check that the title of the pop up is displayed
+    final commentPopupTitle = find.byKey(CommentPopUp.commentPopUpTitleKey);
+    expect(commentPopupTitle, findsOneWidget);
+
+    //Check that the description of the pop up is displayed
+    final commentPopupDescription =
+        find.byKey(CommentPopUp.commentPopUpDescriptionKey);
+    expect(commentPopupDescription, findsOneWidget);
+
+    //Check that the delete button is displayed
+    final commentPopupDeleteButton =
+        find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
+    expect(commentPopupDeleteButton, findsOneWidget);
   });
 }

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -175,7 +175,7 @@ void main() {
       expect(profilePage, findsOneWidget);
     });
 
-    testWidgets("Tab working as expected", (tester) async {
+    testWidgets("Comment popup working as expected", (tester) async {
       await tester.pumpWidget(getMockedProxima());
       await tester.pumpAndSettle();
 

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -74,9 +74,25 @@ void main() {
       );
     }
 
-    testWidgets("Various widget are displayed", (tester) async {
+    Future<void> commonSetup(WidgetTester tester) async {
       await tester.pumpWidget(getMockedProxima());
       await tester.pumpAndSettle();
+
+      //Check that the tab is displayed
+      final tab = find.byKey(ProfilePage.tabKey);
+      expect(tab, findsOneWidget);
+
+      // Check that the post tab is displayed
+      final postTab = find.byKey(ProfilePage.postTabKey);
+      expect(postTab, findsOneWidget);
+
+      // Check that the comment tab is displayed
+      final commentTab = find.byKey(ProfilePage.commentTabKey);
+      expect(commentTab, findsOneWidget);
+    }
+
+    testWidgets("Various widget are displayed", (tester) async {
+      await commonSetup(tester);
 
       // Check that badges are displayed
       final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
@@ -102,28 +118,12 @@ void main() {
       final userAccount = find.byKey(UserAccount.userInfoKey);
       expect(userAccount, findsOneWidget);
 
-      //Check that the tab is displayed
-      final tab = find.byKey(ProfilePage.tabKey);
-      expect(tab, findsOneWidget);
-    });
-
-    testWidgets("Tab working as expected", (tester) async {
-      await tester.pumpWidget(getMockedProxima());
-      await tester.pumpAndSettle();
-
-      // Check that the post tab is displayed
-      final postTab = find.byKey(ProfilePage.postTabKey);
-      expect(postTab, findsOneWidget);
-
-      // Check that the comment tab is displayed
-      final commentTab = find.byKey(ProfilePage.commentTabKey);
-      expect(commentTab, findsOneWidget);
-
       //Check that post column is displayed
       final postColumn = find.byKey(ProfilePage.postColumnKey);
       expect(postColumn, findsOneWidget);
 
       // Tap on the comment tab
+      final commentTab = find.byKey(ProfilePage.commentTabKey);
       await tester.tap(commentTab);
       await tester.pumpAndSettle();
 
@@ -132,102 +132,87 @@ void main() {
       expect(commentColumn, findsOneWidget);
     });
 
-    testWidgets("Post popup working as expected", (tester) async {
-      await tester.pumpWidget(getMockedProxima());
-      await tester.pumpAndSettle();
+    group("Popups working as expected", () {
+      testWidgets("Post popup working as expected", (tester) async {
+        await commonSetup(tester);
 
-      //Check that post column is displayed
-      final postColumn = find.byKey(ProfilePage.postColumnKey);
-      expect(postColumn, findsOneWidget);
+        //Check tab on the first post
+        final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
+        expect(infoCardPost, findsWidgets);
 
-      //Check tab on the first post
-      final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
-      expect(infoCardPost, findsWidgets);
+        // Tap on the first post
+        await tester.tap(infoCardPost.first);
+        await tester.pumpAndSettle();
 
-      // Tap on the first post
-      await tester.tap(infoCardPost.first);
-      await tester.pumpAndSettle();
+        // Check that the post popup is displayed
+        final postPopup = find.byType(PostPopUp);
+        expect(postPopup, findsOneWidget);
 
-      // Check that the post popup is displayed
-      final postPopup = find.byType(PostPopUp);
-      expect(postPopup, findsOneWidget);
+        //Check that the title of the pop up is displayed
+        final postPopupTitle = find.byKey(PostPopUp.postPopUpTitleKey);
+        expect(postPopupTitle, findsOneWidget);
 
-      //Check that the title of the pop up is displayed
-      final postPopupTitle = find.byKey(PostPopUp.postPopUpTitleKey);
-      expect(postPopupTitle, findsOneWidget);
+        //Check that the description of the pop up is displayed
+        final postPopupDescription =
+            find.byKey(PostPopUp.postPopUpDescriptionKey);
+        expect(postPopupDescription, findsOneWidget);
 
-      //Check that the description of the pop up is displayed
-      final postPopupDescription =
-          find.byKey(PostPopUp.postPopUpDescriptionKey);
-      expect(postPopupDescription, findsOneWidget);
+        //Check that the delete button is displayed
+        final postPopupDeleteButton =
+            find.byKey(PostPopUp.postPopUpDeleteButtonKey);
+        expect(postPopupDeleteButton, findsOneWidget);
 
-      //Check that the delete button is displayed
-      final postPopupDeleteButton =
-          find.byKey(PostPopUp.postPopUpDeleteButtonKey);
-      expect(postPopupDeleteButton, findsOneWidget);
+        //Check clicking on the delete button come back to the profile page
+        await tester.tap(postPopupDeleteButton);
+        await tester.pumpAndSettle();
 
-      //Check clicking on the delete button come back to the profile page
-      await tester.tap(postPopupDeleteButton);
-      await tester.pumpAndSettle();
+        //Check that the profile page is displayed
+        final profilePage = find.byType(ProfilePage);
+        expect(profilePage, findsOneWidget);
+      });
 
-      //Check that the profile page is displayed
-      final profilePage = find.byType(ProfilePage);
-      expect(profilePage, findsOneWidget);
-    });
+      testWidgets("Comment popup working as expected", (tester) async {
+        await commonSetup(tester);
 
-    testWidgets("Comment popup working as expected", (tester) async {
-      await tester.pumpWidget(getMockedProxima());
-      await tester.pumpAndSettle();
+        // Tap on the comment tab
+        final commentTab = find.byKey(ProfilePage.commentTabKey);
+        await tester.tap(commentTab);
+        await tester.pumpAndSettle();
 
-      // Check that the comment tab is displayed
-      final commentTab = find.byKey(ProfilePage.commentTabKey);
-      expect(commentTab, findsOneWidget);
+        //Check tab on the first comment
+        final infoCardComment = find.byKey(InfoCardComment.infoCardCommentKey);
+        expect(infoCardComment, findsWidgets);
 
-      //Check that post column is displayed
-      final postColumn = find.byKey(ProfilePage.postColumnKey);
-      expect(postColumn, findsOneWidget);
+        // Tap on the first comment
+        await tester.tap(infoCardComment.first);
+        await tester.pumpAndSettle();
 
-      // Tap on the comment tab
-      await tester.tap(commentTab);
-      await tester.pumpAndSettle();
+        // Check that the comment popup is displayed
+        final commentPopup = find.byType(CommentPopUp);
+        expect(commentPopup, findsOneWidget);
 
-      // Check that the comment column is displayed
-      final commentColumn = find.byKey(ProfilePage.commentColumnKey);
-      expect(commentColumn, findsOneWidget);
+        //Check that the title of the pop up is displayed
+        final commentPopupTitle = find.byKey(CommentPopUp.commentPopUpTitleKey);
+        expect(commentPopupTitle, findsOneWidget);
 
-      //Check tab on the first post
-      final infoCardComment = find.byKey(InfoCardComment.infoCardCommentKey);
-      expect(infoCardComment, findsWidgets);
+        //Check that the description of the pop up is displayed
+        final commentPopupDescription =
+            find.byKey(CommentPopUp.commentPopUpDescriptionKey);
+        expect(commentPopupDescription, findsOneWidget);
 
-      // Tap on the first post
-      await tester.tap(infoCardComment.first);
-      await tester.pumpAndSettle();
+        //Check that the delete button is displayed
+        final commentPopupDeleteButton =
+            find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
+        expect(commentPopupDeleteButton, findsOneWidget);
 
-      // Check that the comment popup is displayed
-      final commentPopup = find.byType(CommentPopUp);
-      expect(commentPopup, findsOneWidget);
+        //Check clicking on the delete button come back to the profile page
+        await tester.tap(commentPopupDeleteButton);
+        await tester.pumpAndSettle();
 
-      //Check that the title of the pop up is displayed
-      final commentPopupTitle = find.byKey(CommentPopUp.commentPopUpTitleKey);
-      expect(commentPopupTitle, findsOneWidget);
-
-      //Check that the description of the pop up is displayed
-      final commentPopupDescription =
-          find.byKey(CommentPopUp.commentPopUpDescriptionKey);
-      expect(commentPopupDescription, findsOneWidget);
-
-      //Check that the delete button is displayed
-      final commentPopupDeleteButton =
-          find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
-      expect(commentPopupDeleteButton, findsOneWidget);
-
-      //Check clicking on the delete button come back to the profile page
-      await tester.tap(commentPopupDeleteButton);
-      await tester.pumpAndSettle();
-
-      //Check that the profile page is displayed
-      final profilePage = find.byType(ProfilePage);
-      expect(profilePage, findsOneWidget);
+        //Check that the profile page is displayed
+        final profilePage = find.byType(ProfilePage);
+        expect(profilePage, findsOneWidget);
+      });
     });
   });
 }


### PR DESCRIPTION
This PR adds a pop-up to posts and comments on the user profile page.

Pop-ups allow the user to see the entire content of the post / comment.
It also adds an ink response upon clicking.

The new pop-up widgets are also entirely tested.

This widget is also working on small phone.

<image src="https://github.com/ProximaEPFL/proxima/assets/53620532/5de5990d-670f-4640-b116-488e55f07c02"
width="300"><image src="https://github.com/ProximaEPFL/proxima/assets/53620532/35e7931a-bdbe-4dd6-8c8d-dc0649c0ca91" width="301">
