### PR TITLE
Add stream implementation to get the nearby posts

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -205,14 +205,6 @@ Future<void> createPost(WidgetTester tester) async {
   await tester.tap(find.byKey(NewPostForm.postButtonKey));
   await tester.pumpAndSettle();
 
-  // refresh the page by pulling down
-  await tester.drag(find.byType(PostFeed), const Offset(0, 500));
-  await tester.pumpAndSettle();
-
-  final refreshButton = find.byKey(PostFeed.refreshButtonKey);
-  await tester.tap(refreshButton);
-  await tester.pumpAndSettle();
-
   // Check that the post is displayed
   expect(find.text(postTitle), findsOneWidget);
   expect(find.text(postDescription), findsOneWidget);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import "package:cloud_firestore/cloud_firestore.dart";
 import "package:firebase_core/firebase_core.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
@@ -11,14 +10,6 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
-  );
-
-  // TODO: Remove this line when the issue is correctly fixed (https://github.com/ProximaEPFL/proxima/issues/78)
-  // This is a workaround that will force the app to fetch the data from the server instead of the cache
-  // hence avoiding the issue of the posts not being updated in the overview
-  // We are basically disabling the cache globally
-  FirebaseFirestore.instance.settings = const Settings(
-    persistenceEnabled: false,
   );
 
   SystemChrome.setPreferredOrientations([

--- a/lib/viewmodels/home_view_model.dart
+++ b/lib/viewmodels/home_view_model.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/ui/post_overview.dart";
 import "package:proxima/services/database/post_repository_service.dart";
@@ -6,60 +8,73 @@ import "package:proxima/services/geolocation_service.dart";
 
 /// This viewmodel is used to fetch the list of posts that are displayed in the home feed.
 /// It fetches the posts from the database and returns a list of [PostOverview] objects to be displayed.
-class HomeViewModel extends AsyncNotifier<List<PostOverview>> {
+/// The viewmodel is a [StreamNotifier] which means that it will emit the list of posts to the UI
+/// whenever the list of posts is updated.
+/// Concretely, if the relevent posts in the database change, the viewmodel will emit a new list of posts
+/// (this also applies to when posts are added or removed from the database).
+///
+/// /!\ If the location of the user changes however, the refresh method must be
+/// called to update the list of nearby posts to the new location. /!\
+class HomeViewModel extends AutoDisposeStreamNotifier<List<PostOverview>> {
   HomeViewModel();
 
   static const kmPostRadius = 0.1;
 
+  /// Builds the stream of posts that will be displayed in the home feed
   @override
-  Future<List<PostOverview>> build() async {
+  Stream<List<PostOverview>> build() async* {
     final geoLocationService = ref.watch(geoLocationServiceProvider);
     final postRepository = ref.watch(postRepositoryProvider);
     final userRepository = ref.watch(userRepositoryProvider);
 
     final position = await geoLocationService.getCurrentPosition();
 
-    final postsFirestore =
-        await postRepository.getNearPosts(position, kmPostRadius);
+    final postsFirestoreStream =
+        postRepository.getNearPosts(position, kmPostRadius);
 
-    final postOwnersId =
-        postsFirestore.map((post) => post.data.ownerId).toSet();
+    final futurePostOverviewsStream =
+        postsFirestoreStream.map((postList) async {
+      final postOwnersId = postList.map((post) => post.data.ownerId).toSet();
 
-    final postOwners = await Future.wait(
-      postOwnersId.map((userId) => userRepository.getUser(userId)),
-    );
-
-    final posts = postsFirestore.map((post) {
-      final owner = postOwners.firstWhere(
-        (user) => user.uid == post.data.ownerId,
-        // This should never be executed in practice as if the owner is not found,
-        // the user repository would have already thrown an exception.
-        orElse: () => throw Exception("Owner not found"),
+      final postOwners = await Future.wait(
+        postOwnersId.map((userId) => userRepository.getUser(userId)),
       );
 
-      return PostOverview(
-        title: post.data.title,
-        description: post.data.description,
-        voteScore: post.data.voteScore,
-        ownerDisplayName: owner.data.displayName,
-        commentNumber:
-            0, // TODO: Update appropriately when comments are implemented
-      );
-    }).toList();
+      final posts = postList.map((post) {
+        final owner = postOwners.firstWhere(
+          (user) => user.uid == post.data.ownerId,
+          // This should never be executed in practice as if the owner is not found,
+          // the user repository would have already thrown an exception.
+          orElse: () => throw Exception("Owner not found"),
+        );
 
-    return posts;
+        return PostOverview(
+          title: post.data.title,
+          description: post.data.description,
+          voteScore: post.data.voteScore,
+          ownerDisplayName: owner.data.displayName,
+          commentNumber:
+              0, // TODO: Update appropriately when comments are implemented
+        );
+      }).toList();
+
+      return posts;
+    });
+
+    await for (final futurePostOverviews in futurePostOverviewsStream) {
+      yield await futurePostOverviews;
+    }
   }
 
-  /// Refresh the list of posts
-  /// This will put the state of the viewmodel to loading, fetch the posts
-  /// and update the state accordingly
-  Future<void> refresh() async {
-    state = const AsyncValue.loading();
-    state = await AsyncValue.guard(() => build());
+  /// Refreshes the list of posts to display the posts that are near the new location of the user
+  /// This method should be called whenever the location of the user changes.
+  void refresh() {
+    state = const AsyncLoading();
+    ref.invalidateSelf();
   }
 }
 
 final postOverviewProvider =
-    AsyncNotifierProvider<HomeViewModel, List<PostOverview>>(
+    AutoDisposeStreamNotifierProvider<HomeViewModel, List<PostOverview>>(
   () => HomeViewModel(),
 );

--- a/lib/views/home_content/feed/post_feed.dart
+++ b/lib/views/home_content/feed/post_feed.dart
@@ -34,7 +34,7 @@ class PostFeed extends HookConsumerWidget {
     final refreshButton = ElevatedButton(
       key: refreshButtonKey,
       onPressed: () async {
-        ref.read(postOverviewProvider.notifier).refresh();
+        return ref.read(postOverviewProvider.notifier).refresh();
       },
       child: const Text("Refresh"),
     );

--- a/test/component/home/navigation_home_test.dart
+++ b/test/component/home/navigation_home_test.dart
@@ -31,7 +31,7 @@ void main() {
     overrides: [
       postOverviewProvider.overrideWith(
         () => MockHomeViewModel(
-          build: () async => testPosts,
+          build: () => Stream.value(testPosts),
         ),
       ),
     ],

--- a/test/component/home/static_home_test.dart
+++ b/test/component/home/static_home_test.dart
@@ -17,7 +17,7 @@ void main() {
     overrides: [
       postOverviewProvider.overrideWith(
         () => MockHomeViewModel(
-          build: () async => testPosts,
+          build: () => Stream.value(testPosts),
         ),
       ),
     ],
@@ -44,8 +44,8 @@ void main() {
       postOverviewProvider.overrideWith(
         () => MockHomeViewModel(
           build: () {
-            // Future.any([]) will never complete and simulate a loading state
-            return Future.any([]);
+            // The stream will never emit any data simulating a loading state
+            return const Stream.empty();
           },
         ),
       ),

--- a/test/services/database/mock_post_repository_service.dart
+++ b/test/services/database/mock_post_repository_service.dart
@@ -51,10 +51,10 @@ class MockPostRepositoryService extends Mock implements PostRepositoryService {
   }
 
   @override
-  Future<List<PostFirestore>> getNearPosts(GeoPoint point, double radius) {
+  Stream<List<PostFirestore>> getNearPosts(GeoPoint point, double radius) {
     return super.noSuchMethod(
       Invocation.method(#getNearPosts, [point, radius]),
-      returnValue: Future.value(List<PostFirestore>.empty()),
+      returnValue: Stream.value(List<PostFirestore>.empty()),
     );
   }
 }

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -96,9 +96,8 @@ void main() {
 
       await setPostFirestore(expectedPost);
 
-      final actualPosts =
-          await postRepository.getNearPosts(userPosition, kmRadius);
-      expect(actualPosts, [expectedPost]);
+      final actualPosts = postRepository.getNearPosts(userPosition, kmRadius);
+      expect(actualPosts, emits([expectedPost]));
     });
 
     test("post is not queried when far away", () async {
@@ -111,9 +110,8 @@ void main() {
 
       await setPostFirestore(expectedPost);
 
-      final actualPosts =
-          await postRepository.getNearPosts(userPosition, kmRadius);
-      expect(actualPosts, isEmpty);
+      final actualPosts = postRepository.getNearPosts(userPosition, kmRadius);
+      expect(actualPosts, emits([]));
     });
 
     test("post on edge (inside) is queried", () async {
@@ -128,9 +126,8 @@ void main() {
 
       await setPostFirestore(expectedPost);
 
-      final actualPosts =
-          await postRepository.getNearPosts(userPosition, kmRadius);
-      expect(actualPosts, [expectedPost]);
+      final actualPosts = postRepository.getNearPosts(userPosition, kmRadius);
+      expect(actualPosts, emits([expectedPost]));
     });
 
     test("post on edge (outside) is not queried", () async {
@@ -145,9 +142,8 @@ void main() {
 
       await setPostFirestore(expectedPost);
 
-      final actualPosts =
-          await postRepository.getNearPosts(userPosition, kmRadius);
-      expect(actualPosts, isEmpty);
+      final actualPosts = postRepository.getNearPosts(userPosition, kmRadius);
+      expect(actualPosts, emits([]));
     });
 
     test("add post at location correctly", () async {
@@ -196,8 +192,7 @@ void main() {
 
       await setPostsFirestore(allPosts);
 
-      final actualPosts =
-          await postRepository.getNearPosts(userPosition, kmRadius);
+      final actualPosts = postRepository.getNearPosts(userPosition, kmRadius);
 
       final expectedPosts = allPosts.where((element) {
         final geoFirePoint = GeoFirePoint(
@@ -211,7 +206,7 @@ void main() {
         return distance <= kmRadius;
       }).toList();
 
-      expect(actualPosts, expectedPosts);
+      expect(actualPosts, emits(expectedPosts));
     });
   });
 }

--- a/test/viewmodels/mock_home_view_model.dart
+++ b/test/viewmodels/mock_home_view_model.dart
@@ -13,7 +13,7 @@ class MockHomeViewModel extends AutoDisposeStreamNotifier<List<PostOverview>>
 
   MockHomeViewModel({
     Stream<List<PostOverview>> Function()? build,
-    Future<void> Function()? onRefresh,
+    void Function()? onRefresh,
   })  : _build = build ?? (() => Stream.value(List<PostOverview>.empty())),
         _onRefresh = onRefresh ?? (() {});
 

--- a/test/viewmodels/mock_home_view_model.dart
+++ b/test/viewmodels/mock_home_view_model.dart
@@ -6,22 +6,22 @@ import "package:proxima/viewmodels/home_view_model.dart";
 /// This class is particularly useful for the UI tests where we want to expose
 /// particular data to the views.
 /// By default it exposes an empty list of [PostOverview] and does nothing on refresh.
-class MockHomeViewModel extends AsyncNotifier<List<PostOverview>>
+class MockHomeViewModel extends AutoDisposeStreamNotifier<List<PostOverview>>
     implements HomeViewModel {
-  final Future<List<PostOverview>> Function() _build;
-  final Future<void> Function() _onRefresh;
+  final Stream<List<PostOverview>> Function() _build;
+  final void Function() _onRefresh;
 
   MockHomeViewModel({
-    Future<List<PostOverview>> Function()? build,
+    Stream<List<PostOverview>> Function()? build,
     Future<void> Function()? onRefresh,
-  })  : _build = build ?? (() async => List<PostOverview>.empty()),
-        _onRefresh = onRefresh ?? (() async {});
+  })  : _build = build ?? (() => Stream.value(List<PostOverview>.empty())),
+        _onRefresh = onRefresh ?? (() {});
 
   @override
-  Future<List<PostOverview>> build() => _build();
+  Stream<List<PostOverview>> build() => _build();
 
   @override
-  Future<void> refresh() => _onRefresh();
+  void refresh() => _onRefresh();
 }
 
 final mockEmptyHomeViewModelOverride = [


### PR DESCRIPTION
Hello,
This PR aims to provide the correct fix to issue #78.
The main idea behind the fix is to expose a `Stream` of posts instead of using a `Future` to query them (which was causing issues as explained in #78).

To do so, this PR does the following:

#### Firestore cache:

The firestore cached is re-enabled as this was only a temporary fix brought by #79.

#### Post Repository:

Refactor the `PostRepository.getNearPost(point, radius)` method in order to directly expose the Stream of posts near the provided location (`point`). 

In practice, a listener is set up on the database for the query and the stream will emit a new list of posts each time the query resolves into a different result. This means that if a post (within `radius` around `point`) is added/removed/modified, the `Stream` will emit a new updated `List<PostFirestore>`.


#### Home View Model:

Refactor the HomeViewModel to work with the `Stream<List<PostFirestore>>`. 

Concretely, the `HomeViewModel` has been transformed into a `AutoDisposeStreamNotifier`. This component works as follow:
- In the `build` method, we create the stream that will expose the `List<PostOverview>`.
- In the UI, the provider is watched with `final asyncPosts = ref.watch(postOverviewProvider);`. (the `AutoDisposeStreamNotifier` exposes and `AsyncValue` when watched, thus `asyncPosts` keeps the type `AsyncValue` like in the previous implementation).
- Now, each time a new `List<PostOverview>` is emitted into the stream, the `postOverviewProvider` will expose a new `AsyncData` with the new `List<PostOverview>`. This will trigger a widget rebuild and thus displaying the new posts.

This has the benefits that when a nearby post is added/removed/modifed, the overview will automatically be updated without the user needing to refresh. (For instance, this means that when the user add a post, he will see it immediately in the overview).

However, the `Stream` created in the `build` is bounded to the location of the user when the `build` was called.
This means that if the user moves, the stream will still be listening for the posts nearby the old location.
This is why still need a `refresh` method.

The `refresh` method is implemented as follows:

```dart
void refresh() {
    state = const AsyncLoading();
    ref.invalidateSelf();
  }
```

So, we start by setting the state to loading to display the circular value on the screen.
Then, we call `ref.invalidateSelf()`. This has for effect of rebuilding the provider.
Concretely, this means that the current stream is closed and that a new one is created with `build`.
During the creation of the new stream, the current user position is queried again leading to a stream listening for posts near the new user location which is what we want. 

#### Tests:

The changes described above lead to the need of refactoring the tests.
I also added added 3 UI tests of the overview to test the display of the error message on failed fetch and the calling of the `refresh` when the refresh button is pressed or the post lists is scrolled down.


### Live testing:

In order to see the impact of the modification while using the application, you have multiple options that you can test.

- You can simply go and add a post at your current location and the post should appear immediately in the overview without needing to refresh.
- You can go into the overview and add some posts. Then, in the firestore console, you can change/remove posts near the device location and you should be able to see the changes appearing in the overview almost instantly without doing anything in the app.


### Ressources:

Here are some ressources that helped me understanding the functioning of dart streams and that you might find usefull:
- Creating streams in Dart : [https://dart.dev/articles/libraries/creating-streams](url)
- Asynchronous programming: Streams : [https://dart.dev/tutorials/language/streams](url)


Thank you for reviewing this PR and I look forward to your feedback :+1: 

