### PR TITLE
Username and Centauri points display 

### DIFF
--- a/lib/models/database/user/user_data.dart
+++ b/lib/models/database/user/user_data.dart
@@ -19,7 +19,7 @@ class UserData {
     required this.username,
     required this.displayName,
     required this.joinTime,
-    this.centauriPoints = 0,
+    required this.centauriPoints,
   });
 
   /// This method will create an instance of [UserData] from the
@@ -30,7 +30,7 @@ class UserData {
         username: data[usernameField],
         displayName: data[displayNameField],
         joinTime: data[joinTimeField],
-        centauriPoints: data[centauriPointsField],
+        centauriPoints: data[centauriPointsField] ?? 0,
       );
     } catch (e) {
       if (e is TypeError) {
@@ -43,13 +43,13 @@ class UserData {
     }
   }
 
-  Map<String, dynamic> addPointstoDbData(int points) {
-    return {
-      usernameField: username,
-      displayNameField: displayName,
-      joinTimeField: joinTime,
-      centauriPointsField: centauriPoints + points,
-    };
+  UserData withPointsAddition(int points) {
+    return UserData(
+      username: username,
+      displayName: displayName,
+      joinTime: joinTime,
+      centauriPoints: centauriPoints + points,
+    );
   }
 
   /// This method will create a map from the current instance of [UserData]

--- a/lib/models/database/user/user_data.dart
+++ b/lib/models/database/user/user_data.dart
@@ -12,10 +12,14 @@ class UserData {
   final Timestamp joinTime;
   static const joinTimeField = "joinTime";
 
+  final int centauriPoints;
+  static const centauriPointsField = "centauriPoints";
+
   const UserData({
     required this.username,
     required this.displayName,
     required this.joinTime,
+    this.centauriPoints = 0,
   });
 
   /// This method will create an instance of [UserData] from the
@@ -26,6 +30,7 @@ class UserData {
         username: data[usernameField],
         displayName: data[displayNameField],
         joinTime: data[joinTimeField],
+        centauriPoints: data[centauriPointsField],
       );
     } catch (e) {
       if (e is TypeError) {
@@ -38,6 +43,15 @@ class UserData {
     }
   }
 
+  Map<String, dynamic> addPointstoDbData(int points) {
+    return {
+      usernameField: username,
+      displayNameField: displayName,
+      joinTimeField: joinTime,
+      centauriPointsField: centauriPoints + points,
+    };
+  }
+
   /// This method will create a map from the current instance of [UserData]
   /// to be stored in firestore
   Map<String, dynamic> toDbData() {
@@ -45,6 +59,7 @@ class UserData {
       usernameField: username,
       displayNameField: displayName,
       joinTimeField: joinTime,
+      centauriPointsField: centauriPoints,
     };
   }
 

--- a/lib/models/ui/profile_data.dart
+++ b/lib/models/ui/profile_data.dart
@@ -1,11 +1,14 @@
+import "package:proxima/models/database/user/user_firestore.dart";
 import "package:proxima/models/login_user.dart";
 
 // TODO (model team) convert to freezed
 // TODO see with UI team what will be displayed for profile
 class ProfileData {
-  final LoginUser user;
+  final LoginUser loginUser;
+  final UserFirestore firestoreUser;
 
   const ProfileData({
-    required this.user,
+    required this.loginUser,
+    required this.firestoreUser,
   });
 }

--- a/lib/services/database/user_repository_service.dart
+++ b/lib/services/database/user_repository_service.dart
@@ -61,9 +61,6 @@ class UserRepositoryService {
 
       transaction.update(userDocRef, updatedUserData);
     });
-    //final user = await getUser(uid);
-    // final updatedUserData = user.data.withPointsAddition(points).toDbData();
-    // await _collectionRef.doc(uid.value).update(updatedUserData);
   }
 }
 

--- a/lib/services/database/user_repository_service.dart
+++ b/lib/services/database/user_repository_service.dart
@@ -44,6 +44,13 @@ class UserRepositoryService {
         .get();
     return query.docs.isNotEmpty;
   }
+
+  /// This method will add [points] to the user with id [uid]
+  Future<void> addPoints(UserIdFirestore uid, int points) async {
+    final user = await getUser(uid);
+    final updatedData = user.data.addPointstoDbData(points);
+    await _collectionRef.doc(uid.value).update(updatedData);
+  }
 }
 
 final userRepositoryProvider = Provider<UserRepositoryService>(

--- a/lib/viewmodels/create_accout_view_model.dart
+++ b/lib/viewmodels/create_accout_view_model.dart
@@ -104,6 +104,7 @@ class CreateAccountViewModel extends AsyncNotifier<CreateAccountModel> {
         username: uniqueUsername,
         displayName: pseudo,
         joinTime: Timestamp.now(),
+        centauriPoints: 0,
       );
       await ref.read(userRepositoryProvider).setUser(uid, userData);
       // Here the [newState.valueOrNull] cannot be null because [newState.valueOrNull?.noError]

--- a/lib/viewmodels/profile_view_model.dart
+++ b/lib/viewmodels/profile_view_model.dart
@@ -7,7 +7,8 @@ import "package:proxima/viewmodels/login_view_model.dart";
 class ProfileViewModel extends AsyncNotifier<ProfileData> {
   ProfileViewModel();
 
-  Future<ProfileData> _fetchData() async {
+  @override
+  Future<ProfileData> build() async {
     final user = ref.watch(userProvider).valueOrNull;
     final userDataBase = ref.watch(userRepositoryProvider);
     final uid = ref.watch(uidProvider);
@@ -25,28 +26,6 @@ class ProfileViewModel extends AsyncNotifier<ProfileData> {
     final userData = await userDataBase.getUser(uid);
 
     return ProfileData(loginUser: user, firestoreUser: userData);
-  }
-
-  @override
-  Future<ProfileData> build() async {
-    return _fetchData();
-  }
-
-  Future<void> addPoints(int points) async {
-    state = const AsyncValue.loading();
-
-    state = await AsyncValue.guard(() async {
-      final uid = ref.watch(uidProvider);
-      final userDataBase = ref.watch(userRepositoryProvider);
-
-      if (uid == null) {
-        return Future.error(
-          "User id was not found.",
-        );
-      }
-      await userDataBase.addPoints(uid, points);
-      return _fetchData();
-    });
   }
 }
 

--- a/lib/viewmodels/profile_view_model.dart
+++ b/lib/viewmodels/profile_view_model.dart
@@ -1,21 +1,52 @@
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/ui/profile_data.dart";
+import "package:proxima/services/database/user_repository_service.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
 
 /// User profile view model
 class ProfileViewModel extends AsyncNotifier<ProfileData> {
   ProfileViewModel();
 
-  @override
-  Future<ProfileData> build() async {
+  Future<ProfileData> _fetchData() async {
     final user = ref.watch(userProvider).valueOrNull;
+    final userDataBase = ref.watch(userRepositoryProvider);
+    final uid = ref.watch(uidProvider);
+
     if (user == null) {
       return Future.error(
         "User must be logged in before displaying the home page.",
       );
     }
+    if (uid == null) {
+      return Future.error(
+        "User id was not found.",
+      );
+    }
+    final userData = await userDataBase.getUser(uid);
 
-    return ProfileData(user: user);
+    return ProfileData(loginUser: user, firestoreUser: userData);
+  }
+
+  @override
+  Future<ProfileData> build() async {
+    return _fetchData();
+  }
+
+  Future<void> addPoints(int points) async {
+    state = const AsyncValue.loading();
+
+    state = await AsyncValue.guard(() async {
+      final uid = ref.watch(uidProvider);
+      final userDataBase = ref.watch(userRepositoryProvider);
+
+      if (uid == null) {
+        return Future.error(
+          "User id was not found.",
+        );
+      }
+      await userDataBase.addPoints(uid, points);
+      return _fetchData();
+    });
   }
 }
 

--- a/lib/views/pages/profile/profile_page.dart
+++ b/lib/views/pages/profile/profile_page.dart
@@ -18,6 +18,7 @@ class ProfilePage extends HookConsumerWidget {
   static const tabKey = Key("tab");
   static const postColumnKey = Key("postColumn");
   static const commentColumnKey = Key("commentColumn");
+  static const settingsKey = Key("settings");
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -71,6 +72,7 @@ class ProfilePage extends HookConsumerWidget {
               ),
               actions: [
                 IconButton(
+                  key: settingsKey,
                   icon: const Icon(Icons.settings),
                   onPressed: () {
                     //add 5 points to the user

--- a/lib/views/pages/profile/profile_page.dart
+++ b/lib/views/pages/profile/profile_page.dart
@@ -65,12 +65,17 @@ class ProfilePage extends HookConsumerWidget {
             appBar: AppBar(
               leading: const LeadingBackButton(),
               title: UserAccount(
-                userEmail: value.user.email ?? "default@mail.com",
+                userName: value.firestoreUser.data.username,
+                userDisplayName: value.firestoreUser.data.displayName,
+                centauriPoints: value.firestoreUser.data.centauriPoints,
               ),
               actions: [
                 IconButton(
                   icon: const Icon(Icons.settings),
-                  onPressed: () {},
+                  onPressed: () {
+                    //add 5 points to the user
+                    ref.read(profileProvider.notifier).addPoints(5);
+                  },
                 ),
               ],
             ),

--- a/lib/views/pages/profile/profile_page.dart
+++ b/lib/views/pages/profile/profile_page.dart
@@ -58,7 +58,6 @@ class ProfilePage extends HookConsumerWidget {
         ),
       );
     }
-
     return switch (asyncUserData) {
       AsyncData(:final value) => DefaultTabController(
           length: 2,
@@ -66,17 +65,14 @@ class ProfilePage extends HookConsumerWidget {
             appBar: AppBar(
               leading: const LeadingBackButton(),
               title: UserAccount(
-                userName: value.firestoreUser.data.username,
-                userDisplayName: value.firestoreUser.data.displayName,
-                centauriPoints: value.firestoreUser.data.centauriPoints,
+                userData: value.firestoreUser.data,
               ),
               actions: [
                 IconButton(
                   key: settingsKey,
                   icon: const Icon(Icons.settings),
                   onPressed: () {
-                    //add 5 points to the user
-                    ref.read(profileProvider.notifier).addPoints(5);
+                    //TODO: implement settings page
                   },
                 ),
               ],

--- a/lib/views/pages/profile/user_info/user_account.dart
+++ b/lib/views/pages/profile/user_info/user_account.dart
@@ -7,10 +7,14 @@ class UserAccount extends StatelessWidget {
 
   const UserAccount({
     super.key,
-    required this.userEmail,
+    required this.userName,
+    required this.userDisplayName,
+    required this.centauriPoints,
   });
 
-  final String userEmail;
+  final String userName;
+  final String userDisplayName;
+  final int centauriPoints;
 
   @override
   Widget build(BuildContext context) {
@@ -29,13 +33,13 @@ class UserAccount extends StatelessWidget {
             children: [
               //TODO: get the profile info from the viewmodel
               Text(
-                userEmail,
+                userDisplayName,
                 style: Theme.of(context).textTheme.titleSmall,
                 overflow: TextOverflow.fade,
               ),
               Text(
                 //TODO: get the user points from the viewmodel
-                "Pseudo · 1000 Centauri ",
+                "$userName · $centauriPoints Centauri ",
                 style: Theme.of(context).textTheme.titleSmall,
                 key: centauriPointsKey,
               ),

--- a/lib/views/pages/profile/user_info/user_account.dart
+++ b/lib/views/pages/profile/user_info/user_account.dart
@@ -39,7 +39,7 @@ class UserAccount extends StatelessWidget {
               ),
               Text(
                 //TODO: get the user points from the viewmodel
-                "$userName · $centauriPoints Centauri ",
+                "$userName · $centauriPoints Centauri",
                 style: Theme.of(context).textTheme.titleSmall,
                 key: centauriPointsKey,
               ),

--- a/lib/views/pages/profile/user_info/user_account.dart
+++ b/lib/views/pages/profile/user_info/user_account.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:proxima/models/database/user/user_data.dart";
 
 /// This widget display the user info in the profile page
 class UserAccount extends StatelessWidget {
@@ -7,17 +8,17 @@ class UserAccount extends StatelessWidget {
 
   const UserAccount({
     super.key,
-    required this.userName,
-    required this.userDisplayName,
-    required this.centauriPoints,
+    required this.userData,
   });
 
-  final String userName;
-  final String userDisplayName;
-  final int centauriPoints;
+  final UserData userData;
 
   @override
   Widget build(BuildContext context) {
+    final userName = userData.username;
+    final userDisplayName = userData.displayName;
+    final centauriPoints = userData.centauriPoints;
+
     return Row(
       key: userInfoKey,
       children: [

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -75,129 +75,189 @@ void main() {
     expect(profilePage, findsOneWidget);
   });
 
+  group("Profile widget page testing", () {
+    setUp(() async {
+      setupFirebaseAuthMocks();
+    });
 
-  testWidgets("Various widget are displayed", (tester) async {
-    setupFirebaseAuthMocks();
+    ProviderScope getMockedProxima() {
+      return ProviderScope(
+        overrides: [
+          firebaseAuthProvider.overrideWith(mockFirebaseAuthSignedIn),
+          userRepositoryProvider.overrideWithValue(userRepo),
+        ],
+        child: const MaterialApp(
+          onGenerateRoute: generateRoute,
+          title: "Profile page",
+          home: ProfilePage(),
+        ),
+      );
+    }
 
-    Widget profilePageWidget = ProviderScope(
-      overrides: [
-        firebaseAuthProvider.overrideWith(mockFirebaseAuthSignedIn),
-        userRepositoryProvider.overrideWithValue(userRepo),
-      ],
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
+    testWidgets("Various widget are displayed", (tester) async {
+      setupFirebaseAuthMocks();
 
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
 
-    // Check that badges are displayed
-    final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
-    expect(badgeCard, findsWidgets);
+      // Check that badges are displayed
+      final badgeCard = find.byKey(InfoCardBadge.infoCardBadgeKey);
+      expect(badgeCard, findsWidgets);
 
-    //Check that the post card is displayed
-    final postCard = find.byKey(InfoCardPost.infoCardPostKey);
-    expect(postCard, findsWidgets);
+      //Check that the post card is displayed
+      final postCard = find.byKey(InfoCardPost.infoCardPostKey);
+      expect(postCard, findsWidgets);
 
-    // Check that the info column is displayed
-    final infoColumn = find.byKey(ProfilePage.postColumnKey);
-    expect(infoColumn, findsOneWidget);
+      // Check that the info column is displayed
+      final infoColumn = find.byKey(ProfilePage.postColumnKey);
+      expect(infoColumn, findsOneWidget);
 
-    // Check that the info row is displayed
-    final infoRowWidget = find.byKey(InfoRow.infoRowKey);
-    expect(infoRowWidget, findsOneWidget);
+      // Check that the info row is displayed
+      final infoRowWidget = find.byKey(InfoRow.infoRowKey);
+      expect(infoRowWidget, findsOneWidget);
 
-    //Check that centauri points are displayed
-    final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
-    expect(centauriPoints, findsOneWidget);
+      //Check that centauri points are displayed
+      final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
+      expect(centauriPoints, findsOneWidget);
 
-    //Check that the user account is displayed
-    final userAccount = find.byKey(UserAccount.userInfoKey);
-    expect(userAccount, findsOneWidget);
+      //Check that the user account is displayed
+      final userAccount = find.byKey(UserAccount.userInfoKey);
+      expect(userAccount, findsOneWidget);
 
-    //Check that the tab is displayed
-    final tab = find.byKey(ProfilePage.tabKey);
-    expect(tab, findsOneWidget);
-  });
+      //Check that the tab is displayed
+      final tab = find.byKey(ProfilePage.tabKey);
+      expect(tab, findsOneWidget);
+    });
 
-  testWidgets("Tab working as expected", (tester) async {
-    setupFirebaseAuthMocks();
+    group("Popups working as expected", () {
+      testWidgets("Post popup working as expected", (tester) async {
+        await tester.pumpWidget(getMockedProxima());
+        await tester.pumpAndSettle();
 
-    Widget profilePageWidget = ProviderScope(
-      overrides: [
-        firebaseAuthProvider.overrideWith(mockFirebaseAuthSignedIn),
-        userRepositoryProvider.overrideWithValue(userRepo),
-      ],
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
+        //Check tab on the first post
+        final infoCardPost = find.byKey(InfoCardPost.infoCardPostKey);
+        expect(infoCardPost, findsWidgets);
 
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
+        // Tap on the first post
+        await tester.tap(infoCardPost.first);
+        await tester.pumpAndSettle();
 
-    // Check that the post tab is displayed
-    final postTab = find.byKey(ProfilePage.postTabKey);
-    expect(postTab, findsOneWidget);
+        // Check that the post popup is displayed
+        final postPopup = find.byType(PostPopUp);
+        expect(postPopup, findsOneWidget);
 
-    // Check that the comment tab is displayed
-    final commentTab = find.byKey(ProfilePage.commentTabKey);
-    expect(commentTab, findsOneWidget);
+        //Check that the title of the pop up is displayed
+        final postPopupTitle = find.byKey(PostPopUp.postPopUpTitleKey);
+        expect(postPopupTitle, findsOneWidget);
 
-    //Check that post column is displayed
-    final postColumn = find.byKey(ProfilePage.postColumnKey);
-    expect(postColumn, findsOneWidget);
+        //Check that the description of the pop up is displayed
+        final postPopupDescription =
+            find.byKey(PostPopUp.postPopUpDescriptionKey);
+        expect(postPopupDescription, findsOneWidget);
 
-    // Tap on the comment tab
-    await tester.tap(commentTab);
-    await tester.pumpAndSettle();
+        //Check that the delete button is displayed
+        final postPopupDeleteButton =
+            find.byKey(PostPopUp.postPopUpDeleteButtonKey);
+        expect(postPopupDeleteButton, findsOneWidget);
 
-    // Check that the comment column is displayed
-    final commentColumn = find.byKey(ProfilePage.commentColumnKey);
-    expect(commentColumn, findsOneWidget);
-  });
+        //Check clicking on the delete button come back to the profile page
+        await tester.tap(postPopupDeleteButton);
+        await tester.pumpAndSettle();
 
-  testWidgets("Centauri points incrementing correctly", (tester) async {
-    setupFirebaseAuthMocks();
+        //Check that the profile page is displayed
+        final profilePage = find.byType(ProfilePage);
+        expect(profilePage, findsOneWidget);
+      });
 
-    Widget profilePageWidget = ProviderScope(
-      overrides: [
-        firebaseAuthProvider.overrideWith(mockFirebaseAuthSignedIn),
-        userRepositoryProvider.overrideWithValue(userRepo),
-      ],
-      child: const MaterialApp(
-        onGenerateRoute: generateRoute,
-        title: "Profile page",
-        home: ProfilePage(),
-      ),
-    );
+      testWidgets("Comment popup working as expected", (tester) async {
+        await tester.pumpWidget(getMockedProxima());
+        await tester.pumpAndSettle();
 
-    await tester.pumpWidget(profilePageWidget);
-    await tester.pumpAndSettle();
+        // Tap on the comment tab
+        final commentTab = find.byKey(ProfilePage.commentTabKey);
+        await tester.tap(commentTab);
+        await tester.pumpAndSettle();
 
-    //Check that centauri points are displayed
-    final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
-    expect(centauriPoints, findsOneWidget);
+        //Check tab on the first comment
+        final infoCardComment = find.byKey(InfoCardComment.infoCardCommentKey);
+        expect(infoCardComment, findsWidgets);
 
-    // checking the text
-    final centauriText = find.text("username_8456 · 0 Centauri");
-    expect(centauriText, findsOneWidget);
+        // Tap on the first comment
+        await tester.tap(infoCardComment.first);
+        await tester.pumpAndSettle();
 
-    //TODO: remove this test when the setting button is implemented
-    final settingsButton = find.byKey(ProfilePage.settingsKey);
-    expect(settingsButton, findsOneWidget);
+        // Check that the comment popup is displayed
+        final commentPopup = find.byType(CommentPopUp);
+        expect(commentPopup, findsOneWidget);
 
-    // Tap on the settings button
-    await tester.tap(settingsButton);
-    await tester.pumpAndSettle();
+        //Check that the description of the pop up is displayed
+        final commentPopupDescription =
+            find.byKey(CommentPopUp.commentPopUpDescriptionKey);
+        expect(commentPopupDescription, findsOneWidget);
 
-    //Check that the centauri points are incremented
-    final centauriPointsIncremented = find.text("username_8456 · 5 Centauri");
-    expect(centauriPointsIncremented, findsOneWidget);
+        //Check that the delete button is displayed
+        final commentPopupDeleteButton =
+            find.byKey(CommentPopUp.commentPopUpDeleteButtonKey);
+        expect(commentPopupDeleteButton, findsOneWidget);
+
+        //Check clicking on the delete button come back to the profile page
+        await tester.tap(commentPopupDeleteButton);
+        await tester.pumpAndSettle();
+
+        //Check that the profile page is displayed
+        final profilePage = find.byType(ProfilePage);
+        expect(profilePage, findsOneWidget);
+      });
+    });
+
+    testWidgets("Tab working as expected", (tester) async {
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
+
+      // Check that the post tab is displayed
+      final postTab = find.byKey(ProfilePage.postTabKey);
+      expect(postTab, findsOneWidget);
+
+      // Check that the comment tab is displayed
+      final commentTab = find.byKey(ProfilePage.commentTabKey);
+      expect(commentTab, findsOneWidget);
+
+      //Check that post column is displayed
+      final postColumn = find.byKey(ProfilePage.postColumnKey);
+      expect(postColumn, findsOneWidget);
+
+      // Tap on the comment tab
+      await tester.tap(commentTab);
+      await tester.pumpAndSettle();
+
+      // Check that the comment column is displayed
+      final commentColumn = find.byKey(ProfilePage.commentColumnKey);
+      expect(commentColumn, findsOneWidget);
+    });
+
+    testWidgets("Centauri points incrementing correctly", (tester) async {
+      await tester.pumpWidget(getMockedProxima());
+      await tester.pumpAndSettle();
+
+      //Check that centauri points are displayed
+      final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
+      expect(centauriPoints, findsOneWidget);
+
+      // checking the text
+      final centauriText = find.text("username_8456 · 0 Centauri");
+      expect(centauriText, findsOneWidget);
+
+      //TODO: remove this test when the setting button is implemented
+      final settingsButton = find.byKey(ProfilePage.settingsKey);
+      expect(settingsButton, findsOneWidget);
+
+      // Tap on the settings button
+      await tester.tap(settingsButton);
+      await tester.pumpAndSettle();
+
+      //Check that the centauri points are incremented
+      final centauriPointsIncremented = find.text("username_8456 · 5 Centauri");
+      expect(centauriPointsIncremented, findsOneWidget);
+    });
   });
 }

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -235,7 +235,7 @@ void main() {
       expect(commentColumn, findsOneWidget);
     });
 
-    testWidgets("Centauri points incrementing correctly", (tester) async {
+    testWidgets("Centauri points displayed correctly", (tester) async {
       await tester.pumpWidget(getMockedProxima());
       await tester.pumpAndSettle();
 
@@ -246,18 +246,6 @@ void main() {
       // checking the text
       final centauriText = find.text("username_8456 · 0 Centauri");
       expect(centauriText, findsOneWidget);
-
-      //TODO: remove this test when the setting button is implemented
-      final settingsButton = find.byKey(ProfilePage.settingsKey);
-      expect(settingsButton, findsOneWidget);
-
-      // Tap on the settings button
-      await tester.tap(settingsButton);
-      await tester.pumpAndSettle();
-
-      //Check that the centauri points are incremented
-      final centauriPointsIncremented = find.text("username_8456 · 5 Centauri");
-      expect(centauriPointsIncremented, findsOneWidget);
     });
   });
 }

--- a/test/component/profile_page_test.dart
+++ b/test/component/profile_page_test.dart
@@ -157,4 +157,43 @@ void main() {
     final commentColumn = find.byKey(ProfilePage.commentColumnKey);
     expect(commentColumn, findsOneWidget);
   });
+
+  testWidgets("Centauri points incrementing correctly", (tester) async {
+    setupFirebaseAuthMocks();
+
+    Widget profilePageWidget = ProviderScope(
+      overrides: [
+        firebaseAuthProvider.overrideWith(mockFirebaseAuthSignedIn),
+        userRepositoryProvider.overrideWithValue(userRepo),
+      ],
+      child: const MaterialApp(
+        onGenerateRoute: generateRoute,
+        title: "Profile page",
+        home: ProfilePage(),
+      ),
+    );
+
+    await tester.pumpWidget(profilePageWidget);
+    await tester.pumpAndSettle();
+
+    //Check that centauri points are displayed
+    final centauriPoints = find.byKey(UserAccount.centauriPointsKey);
+    expect(centauriPoints, findsOneWidget);
+
+    // checking the text
+    final centauriText = find.text("username_8456 · 0 Centauri");
+    expect(centauriText, findsOneWidget);
+
+    //TODO: remove this test when the setting button is implemented
+    final settingsButton = find.byKey(ProfilePage.settingsKey);
+    expect(settingsButton, findsOneWidget);
+
+    // Tap on the settings button
+    await tester.tap(settingsButton);
+    await tester.pumpAndSettle();
+
+    //Check that the centauri points are incremented
+    final centauriPointsIncremented = find.text("username_8456 · 5 Centauri");
+    expect(centauriPointsIncremented, findsOneWidget);
+  });
 }

--- a/test/models/database/user/mock_user_data.dart
+++ b/test/models/database/user/mock_user_data.dart
@@ -12,6 +12,7 @@ class MockUserFirestore {
         displayName: "display_name_$i",
         username: "username_$i",
         joinTime: Timestamp.fromMillisecondsSinceEpoch(1000 * i),
+        centauriPoints: i,
       );
     });
   }

--- a/test/services/database/mock_user_repository_service.dart
+++ b/test/services/database/mock_user_repository_service.dart
@@ -12,6 +12,7 @@ final _mockEmptyFirestoreUser = UserFirestore(
     displayName: "",
     username: "",
     joinTime: Timestamp.fromMillisecondsSinceEpoch(0),
+    centauriPoints: 0,
   ),
   uid: const UserIdFirestore(value: ""),
 );

--- a/test/services/database/user_repository_test.dart
+++ b/test/services/database/user_repository_test.dart
@@ -116,5 +116,22 @@ void main() {
 
       expect(isUsernameTaken, false);
     });
+
+    test("Update centauri points", () async {
+      final expectedUser = testingUserFirestore;
+
+      await userCollection
+          .doc(expectedUser.uid.value)
+          .set(expectedUser.data.toDbData());
+
+      const pointsToAdd = 100;
+
+      await userRepo.addPoints(expectedUser.uid, pointsToAdd);
+
+      //get the centauri points from the db
+      await userCollection.doc(expectedUser.uid.value).get().then((value) {
+        expect(value.data()![UserData.centauriPointsField], pointsToAdd);
+      });
+    });
   });
 }

--- a/test/services/database/user_repository_test.dart
+++ b/test/services/database/user_repository_test.dart
@@ -129,9 +129,16 @@ void main() {
       await userRepo.addPoints(expectedUser.uid, pointsToAdd);
 
       //get the centauri points from the db
-      await userCollection.doc(expectedUser.uid.value).get().then((value) {
-        expect(value.data()![UserData.centauriPointsField], pointsToAdd);
-      });
+      final actualUserDoc =
+          await userCollection.doc(expectedUser.uid.value).get();
+
+      final actualCentauriPoints =
+          actualUserDoc.data()![UserData.centauriPointsField];
+
+      expect(
+        actualCentauriPoints,
+        expectedUser.data.centauriPoints + pointsToAdd,
+      );
     });
   });
 }

--- a/test/services/test_data/firestore_user_mock.dart
+++ b/test/services/test_data/firestore_user_mock.dart
@@ -9,6 +9,7 @@ final testingUserData = UserData(
   username: "username_8456",
   displayName: "display_name_8456",
   joinTime: Timestamp.fromMillisecondsSinceEpoch(10054217),
+  centauriPoints: 0,
 );
 
 final testingUserFirestoreId = UserIdFirestore(value: testingLoginUser.uid);


### PR DESCRIPTION
This pull request implements a new user data viewmodel that provides more information for the different screens of the app. Here are the main features brought with this PR:

1. **Real username and displayname displayed** : Those two attributes of the user are now retrieved from firestore and are thus not mock data anymore. 

2. **First implementation of the centauri points** : User have now a "centauri points" field in the database. User have 0 points by default. For now, you can increment your points (+5) by clicking on the "settings" button in the user profile screen. The data you see and increment on the screen  is retrieved and stored in the database (not a mock example).

3. **centauri points test** : A new test checks that the "increment" feature of the centauri points is working correctly.

<img width="403" alt="Capture d’écran 2024-04-16 à 10 07 18" src="https://github.com/ProximaEPFL/proxima/assets/92913266/c91ac063-332e-4349-9001-b2c0d7a6f338">
