### PR TITLE
User posts query

### DIFF
--- a/lib/services/database/post_repository_service.dart
+++ b/lib/services/database/post_repository_service.dart
@@ -4,6 +4,8 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/post/post_data.dart";
 import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/models/database/post/post_location_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
 import "package:proxima/services/database/firestore_service.dart";
 
 /// This repository service is responsible for managing the posts in the database
@@ -71,6 +73,15 @@ class PostRepositoryService {
           ) <=
           radius;
     }).toList();
+  }
+
+  /// This method will retrieve all the posts belonging to a given user
+  Future<List<PostFirestore>> getUserPosts(UserIdFirestore userId) async {
+    final userPosts = await _collectionRef
+        .where(PostData.ownerIdField, isEqualTo: userId.value)
+        .get();
+
+    return userPosts.docs.map((data) => PostFirestore.fromDb(data)).toList();
   }
 
   GeoFirePoint _getGeoFirePoint(GeoPoint point) {

--- a/lib/services/database/post_repository_service.dart
+++ b/lib/services/database/post_repository_service.dart
@@ -4,7 +4,6 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/post/post_data.dart";
 import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
-import "package:proxima/models/database/post/post_location_firestore.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
 import "package:proxima/services/database/firestore_service.dart";
 

--- a/test/models/database/post/mock_post_data.dart
+++ b/test/models/database/post/mock_post_data.dart
@@ -45,7 +45,7 @@ class MockPostFirestore {
         ownerId: userId,
         title: "title",
         description: "desciption",
-        publicationTime: Timestamp.now(),
+        publicationTime: Timestamp.fromMicrosecondsSinceEpoch(1000000),
         voteScore: Random().nextInt(100),
       ),
     );

--- a/test/models/database/post/mock_post_data.dart
+++ b/test/models/database/post/mock_post_data.dart
@@ -1,3 +1,5 @@
+import "dart:math";
+
 import "package:cloud_firestore/cloud_firestore.dart";
 import "package:geoflutterfire2/geoflutterfire2.dart";
 import "package:proxima/models/database/post/post_data.dart";
@@ -22,6 +24,30 @@ class MockPostFirestore {
         geohash: point.hash,
       ),
       data: data,
+    );
+  }
+
+  static PostFirestore createUserPost(
+    UserIdFirestore userId,
+    GeoPoint location,
+  ) {
+    final point = GeoFirePoint(location.latitude, location.longitude);
+
+    return PostFirestore(
+      id: PostIdFirestore(
+        value: DateTime.now().microsecondsSinceEpoch.toString(),
+      ),
+      location: PostLocationFirestore(
+        geoPoint: location,
+        geohash: point.hash,
+      ),
+      data: PostData(
+        ownerId: userId,
+        title: "title",
+        description: "desciption",
+        publicationTime: Timestamp.now(),
+        voteScore: Random().nextInt(100),
+      ),
     );
   }
 

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -235,15 +235,8 @@ void main() {
       final actualPosts1 = await postRepository.getUserPosts(userId1);
       final actualPosts2 = await postRepository.getUserPosts(userId2);
 
-      expect(actualPosts1.length, 2);
-      expect(actualPosts1.length, actualPosts2.length);
-
-      for (final post in actualPosts1) {
-        expect(post.data.ownerId.value, userId1.value);
-      }
-      for (final post in actualPosts2) {
-        expect(post.data.ownerId.value, userId2.value);
-      }
+      expect(actualPosts1, unorderedEquals([postsData1, postsData2]));
+      expect(actualPosts2, unorderedEquals([postsData3, postsData4]));
     });
   });
 }

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -10,6 +10,7 @@ import "package:proxima/models/database/user/user_id_firestore.dart";
 import "package:proxima/services/database/post_repository_service.dart";
 
 import "../../models/database/post/mock_post_data.dart";
+import "../test_data/user_posts_fake_data.dart";
 
 void main() {
   group("Post Repository testing", () {
@@ -212,6 +213,37 @@ void main() {
       }).toList();
 
       expect(actualPosts, expectedPosts);
+    });
+
+    test("get simple user posts correctly", () async {
+      const userId1 = UserIdFirestore(value: "user_id_1");
+
+      final postsData1 =
+          MockPostFirestore.createUserPost(userId1, fakeDataPosition1);
+      final postsData2 =
+          MockPostFirestore.createUserPost(userId1, fakeDataPosition2);
+      await setPostsFirestore([postsData1, postsData2]);
+
+      const userId2 = UserIdFirestore(value: "user_id_2");
+
+      final postsData3 =
+          MockPostFirestore.createUserPost(userId2, fakeDataPosition1);
+      final postsData4 =
+          MockPostFirestore.createUserPost(userId2, fakeDataPosition2);
+      await setPostsFirestore([postsData3, postsData4]);
+
+      final actualPosts1 = await postRepository.getUserPosts(userId1);
+      final actualPosts2 = await postRepository.getUserPosts(userId2);
+
+      expect(actualPosts1.length, 2);
+      expect(actualPosts1.length, actualPosts2.length);
+
+      for (final post in actualPosts1) {
+        expect(post.data.ownerId.value, userId1.value);
+      }
+      for (final post in actualPosts2) {
+        expect(post.data.ownerId.value, userId2.value);
+      }
     });
   });
 }

--- a/test/services/test_data/user_posts_fake_data.dart
+++ b/test/services/test_data/user_posts_fake_data.dart
@@ -1,0 +1,4 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+
+const fakeDataPosition1 = GeoPoint(10, 10);
+const fakeDataPosition2 = GeoPoint(50, 100);


### PR DESCRIPTION
A new query functionality on the model aspect that allows any viewmodel to retrieve the lists of posts of a given user.

This functionality will prove itself particularly useful for the viewmodel of the profile page, where we want to display all the posts of a given user.

Fixes #104 