### PR TITLE
Circular value error handling

### DIFF
--- a/lib/utils/ui/circular_value.dart
+++ b/lib/utils/ui/circular_value.dart
@@ -4,6 +4,9 @@ import "package:proxima/utils/ui/error_alert.dart";
 
 /// Utilitiy widget used to display a [CircularProgressIndicator] while waiting
 /// for an [AsyncValue] to complete; and another widget once the data resolves.
+/// In case the data resolves to an error, an [ErrorAlert] dialog is shown, and
+/// a fallback widget is displayed. The default fallback widget is empty, but it
+/// can be overridden.
 class CircularValue<T> extends StatelessWidget {
   final AsyncValue<T> value;
   final Widget Function(BuildContext context, T data) builder;
@@ -12,6 +15,11 @@ class CircularValue<T> extends StatelessWidget {
   static Widget _defaultFallback(BuildContext context, Object error) =>
       const SizedBox.shrink();
 
+  /// Constructor for the [CircularValue] widget.
+  /// [value] is the underlying [AsyncValue] that controls the display.
+  /// [builder] is the widget to display when the [value] is [AsyncValue.data].
+  /// [fallbackBuilder] is the widget to display when the [value] is [AsyncValue.error].
+  /// The default [fallbackBuilder] is an empty [SizedBox].
   const CircularValue({
     super.key,
     required this.value,

--- a/lib/utils/ui/circular_value.dart
+++ b/lib/utils/ui/circular_value.dart
@@ -7,11 +7,16 @@ import "package:proxima/utils/ui/error_alert.dart";
 class CircularValue<T> extends StatelessWidget {
   final AsyncValue<T> value;
   final Widget Function(BuildContext context, T data) builder;
+  final Widget Function(BuildContext context, Object error) fallbackBuilder;
+
+  static Widget _defaultFallback(BuildContext context, Object error) =>
+      const SizedBox.shrink();
 
   const CircularValue({
     super.key,
     required this.value,
     required this.builder,
+    this.fallbackBuilder = _defaultFallback,
   });
 
   @override
@@ -21,7 +26,7 @@ class CircularValue<T> extends StatelessWidget {
       error: (error, _) {
         final dialog = ErrorAlert(error: error);
         showDialog(context: context, builder: dialog.build);
-        return Container();
+        return fallbackBuilder(context, error);
       },
       orElse: () {
         return const Center(

--- a/lib/utils/ui/circular_value.dart
+++ b/lib/utils/ui/circular_value.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/utils/ui/error_alert.dart";
 
 /// Utilitiy widget used to display a [CircularProgressIndicator] while waiting
 /// for an [AsyncValue] to complete; and another widget once the data resolves.
@@ -17,6 +18,11 @@ class CircularValue<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     return value.maybeWhen(
       data: (data) => builder(context, data),
+      error: (error, _) {
+        final dialog = ErrorAlert(error: error);
+        showDialog(context: context, builder: dialog.build);
+        return Container();
+      },
       orElse: () {
         return const Center(
           child: CircularProgressIndicator(),

--- a/lib/utils/ui/error_alert.dart
+++ b/lib/utils/ui/error_alert.dart
@@ -1,8 +1,11 @@
 import "package:flutter/material.dart";
 
+/// A simple alert dialog that displays an error message.
 class ErrorAlert extends StatelessWidget {
   static const okButtonKey = Key("okButton");
 
+  /// Constructor for the [ErrorAlert] widget.
+  /// [error] is the error object to display.
   const ErrorAlert({
     super.key,
     required this.error,

--- a/lib/utils/ui/error_alert.dart
+++ b/lib/utils/ui/error_alert.dart
@@ -1,6 +1,8 @@
 import "package:flutter/material.dart";
 
 class ErrorAlert extends StatelessWidget {
+  static const okButtonKey = Key("okButton");
+
   const ErrorAlert({
     super.key,
     required this.error,
@@ -18,6 +20,7 @@ class ErrorAlert extends StatelessWidget {
           onPressed: () {
             Navigator.of(context).pop();
           },
+          key: okButtonKey,
           child: const Text("OK"),
         ),
       ],

--- a/lib/utils/ui/error_alert.dart
+++ b/lib/utils/ui/error_alert.dart
@@ -1,0 +1,27 @@
+import "package:flutter/cupertino.dart";
+import "package:flutter/material.dart";
+
+class ExceptionAlert extends StatelessWidget {
+  const ExceptionAlert({
+    super.key,
+    required this.exception,
+  });
+
+  final Exception exception;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("An error occurred"),
+      content: Text(exception.toString()),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text("OK"),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/utils/ui/error_alert.dart
+++ b/lib/utils/ui/error_alert.dart
@@ -1,4 +1,3 @@
-import "package:flutter/cupertino.dart";
 import "package:flutter/material.dart";
 
 class ErrorAlert extends StatelessWidget {

--- a/lib/utils/ui/error_alert.dart
+++ b/lib/utils/ui/error_alert.dart
@@ -1,19 +1,19 @@
 import "package:flutter/cupertino.dart";
 import "package:flutter/material.dart";
 
-class ExceptionAlert extends StatelessWidget {
-  const ExceptionAlert({
+class ErrorAlert extends StatelessWidget {
+  const ErrorAlert({
     super.key,
-    required this.exception,
+    required this.error,
   });
 
-  final Exception exception;
+  final Object error;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text("An error occurred"),
-      content: Text(exception.toString()),
+      content: Text(error.toString()),
       actions: <Widget>[
         TextButton(
           onPressed: () {

--- a/lib/viewmodels/new_post_view_model.dart
+++ b/lib/viewmodels/new_post_view_model.dart
@@ -36,19 +36,22 @@ class NewPostViewModel extends AutoDisposeAsyncNotifier<NewPostState> {
   }
 
   /// Verifies that the title and description are not empty, then adds a new post to the database.
-  /// If the user is not logged in, an exception is thrown.
   /// If the title or description is empty, the state is updated with the appropriate error message.
   /// If the post is successfully added, the state is updated with the posted flag set to true.
   Future<void> addPost(String title, String description) async {
     state = const AsyncLoading();
+    state = await AsyncValue.guard(() => _addPost(title, description));
+  }
 
+  Future<NewPostState> _addPost(String title, String description) async {
     final currentUser = ref.read(uidProvider);
     if (currentUser == null) {
       throw Exception("User must be logged in before creating a post");
     }
 
     if (!validate(title, description)) {
-      return;
+      // not loading or error since validation failed and wrote to the state
+      return state.value!;
     }
 
     final currPosition =
@@ -65,12 +68,10 @@ class NewPostViewModel extends AutoDisposeAsyncNotifier<NewPostState> {
 
     await postRepository.addPost(post, currPosition);
 
-    state = AsyncData(
-      NewPostState(
-        titleError: null,
-        descriptionError: null,
-        posted: true,
-      ),
+    return NewPostState(
+      titleError: null,
+      descriptionError: null,
+      posted: true,
     );
   }
 }

--- a/lib/views/home_content/feed/post_feed.dart
+++ b/lib/views/home_content/feed/post_feed.dart
@@ -58,13 +58,15 @@ class PostFeed extends HookConsumerWidget {
       ),
     );
 
-    final fallback = Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        const Text("An error occurred"),
-        const SizedBox(height: 10),
-        refreshButton,
-      ],
+    final fallback = Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text("An error occurred"),
+          const SizedBox(height: 10),
+          refreshButton,
+        ],
+      ),
     );
 
     return Column(
@@ -73,61 +75,24 @@ class PostFeed extends HookConsumerWidget {
           key: feedSortOptionKey,
         ),
         const Divider(),
-        CircularValue(
-          value: asyncPosts,
-          builder: (context, posts) {
-            final postsList = PostList(
-              posts: posts,
-              onRefresh: () async {
-                return ref.read(postOverviewProvider.notifier).refresh();
-              },
-            );
+        Expanded(
+          child: CircularValue(
+            value: asyncPosts,
+            builder: (context, posts) {
+              final postsList = PostList(
+                posts: posts,
+                onRefresh: () async {
+                  return ref.read(postOverviewProvider.notifier).refresh();
+                },
+              );
 
-            return Expanded(
-              child: posts.isEmpty ? emptyHelper : postsList,
-            );
-          },
-          fallbackBuilder: (context, error) {
-            return fallback;
-          },
+              return posts.isEmpty ? emptyHelper : postsList;
+            },
+            fallbackBuilder: (context, error) {
+              return fallback;
+            },
+          ),
         ),
-
-        /*
-        asyncPosts.when(
-          data: (posts) {
-            final postsList = PostList(
-              posts: posts,
-              onRefresh: () async {
-                return ref.read(postOverviewProvider.notifier).refresh();
-              },
-            );
-
-            return Expanded(
-              child: posts.isEmpty ? emptyHelper : postsList,
-            );
-          },
-          loading: () {
-            return const Expanded(
-              child: Center(
-                child: CircularProgressIndicator(),
-              ),
-            );
-          },
-          error: (error, _) {
-            return Expanded(
-              child: Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text("An error occurred"),
-                    const SizedBox(height: 10),
-                    refreshButton,
-                  ],
-                ),
-              ),
-            );
-          },
-        ),*/
       ],
     );
   }

--- a/lib/views/home_content/feed/post_feed.dart
+++ b/lib/views/home_content/feed/post_feed.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/ui/post_overview.dart";
+import "package:proxima/utils/ui/circular_value.dart";
 import "package:proxima/viewmodels/home_view_model.dart";
 import "package:proxima/views/home_content/feed/post_card/post_card.dart";
 import "package:proxima/views/navigation/routes.dart";
@@ -15,6 +16,7 @@ class PostFeed extends HookConsumerWidget {
   static const feedKey = Key("feed");
   static const emptyfeedKey = Key("emptyFeed");
   static const newPostButtonTextKey = Key("newPostButtonTextKey");
+
   const PostFeed({super.key});
 
   @override
@@ -56,12 +58,41 @@ class PostFeed extends HookConsumerWidget {
       ),
     );
 
+    final fallback = Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text("An error occurred"),
+        const SizedBox(height: 10),
+        refreshButton,
+      ],
+    );
+
     return Column(
       children: [
         const FeedSortOptionChips(
           key: feedSortOptionKey,
         ),
         const Divider(),
+        CircularValue(
+          value: asyncPosts,
+          builder: (context, posts) {
+            final postsList = PostList(
+              posts: posts,
+              onRefresh: () async {
+                return ref.read(postOverviewProvider.notifier).refresh();
+              },
+            );
+
+            return Expanded(
+              child: posts.isEmpty ? emptyHelper : postsList,
+            );
+          },
+          fallbackBuilder: (context, error) {
+            return fallback;
+          },
+        ),
+
+        /*
         asyncPosts.when(
           data: (posts) {
             final postsList = PostList(
@@ -96,7 +127,7 @@ class PostFeed extends HookConsumerWidget {
               ),
             );
           },
-        ),
+        ),*/
       ],
     );
   }

--- a/test/component/utils/ui/circular_value_test.dart
+++ b/test/component/utils/ui/circular_value_test.dart
@@ -1,0 +1,72 @@
+import "dart:math";
+
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/utils/ui/circular_value.dart";
+import "package:proxima/utils/ui/error_alert.dart";
+
+void main() {
+  Widget testCircularValue(AsyncValue<void> value) => CircularValue(
+        value: value,
+        builder: (context, data) => const Text("Completed"),
+        fallbackBuilder: (context, error) => const Text("Strange Error"),
+      );
+
+  testWidgets(
+      "CircularValue should show CircularProgressIndicator when loading", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: testCircularValue(const AsyncValue.loading()),
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets("CicularValue should build with value when finished", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: testCircularValue(const AsyncValue.data(null)),
+        ),
+      ),
+    );
+
+    expect(find.text("Completed"), findsOneWidget);
+  });
+
+  testWidgets("CicularValue should build error when error", (
+    tester,
+  ) async {
+    final testException = Exception("Blue moon");
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: testCircularValue(
+              AsyncValue.error(testException, StackTrace.empty)),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // expect to find a popup dialog
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.textContaining("Blue moon"), findsOneWidget);
+    // find ok button
+    final okButton = find.byKey(ErrorAlert.okButtonKey);
+    expect(okButton, findsOneWidget);
+    await tester.tap(okButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text("Strange Error"), findsOneWidget);
+  });
+}

--- a/test/component/utils/ui/circular_value_test.dart
+++ b/test/component/utils/ui/circular_value_test.dart
@@ -1,5 +1,3 @@
-import "dart:math";
-
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
@@ -51,7 +49,8 @@ void main() {
       ProviderScope(
         child: MaterialApp(
           home: testCircularValue(
-              AsyncValue.error(testException, StackTrace.empty)),
+            AsyncValue.error(testException, StackTrace.empty),
+          ),
         ),
       ),
     );

--- a/test/component/utils/ui/circular_value_test.dart
+++ b/test/component/utils/ui/circular_value_test.dart
@@ -37,6 +37,7 @@ void main() {
       ),
     );
 
+    await tester.pumpAndSettle();
     expect(find.text("Completed"), findsOneWidget);
   });
 


### PR DESCRIPTION
Addresses #107 
This PR adds error handling to CircularValue. This allows us to reuse this component anywhere we have an AsyncValue, and automatically handle errors.

When the AsyncValue becomes and error, a fallback widget is built in place of the CircularValue, and an error popup is shown with a string representation of the error. The default fallback widget is an empty widget. The default fallback is empty because the circular value might be used in small spaces, where there is no room to show any text.

PostFeed has been adapted to use CircularValue, and to show the previous error message with a refresh button as a fallback widget.
NewPostViewModel has been updated with a guard, to catch errors and store them in the AsyncValue state.

You can see the error handling in action by disabling the position service and refreshing the home page or trying to add a new post.

After refreshing the new post page, first we get a popup:
![image](https://github.com/ProximaEPFL/proxima/assets/82676334/eb479a08-75ca-4d08-b73f-e2afd2e338e2)

And then as fallback the same screen as before:
![image](https://github.com/ProximaEPFL/proxima/assets/82676334/a68bcbf4-b752-4b5f-881c-01065f5faf79)

On the new post page, after clicking on post with location off we get the popup:
![image](https://github.com/ProximaEPFL/proxima/assets/82676334/ad545d9f-9970-4e53-8988-a026c882e3e0)

And then the empty default fallback:
![image](https://github.com/ProximaEPFL/proxima/assets/82676334/1473b8e3-f5c4-4d57-bab9-acbcc035d138)


In later PR's we can imagine creating custom popups for different exception types. We will also have to think about handling the case when we do not have internet connection. Currently the post feed returns an empty feed without throwing an error, and the new post page hangs forever without throwing an error.