### PR TITLE
Geoflutterfireplus refactor

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import "package:cloud_firestore/cloud_firestore.dart";
 import "package:firebase_core/firebase_core.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
@@ -11,14 +10,6 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
-  );
-
-  // TODO: Remove this line when the issue is correctly fixed (https://github.com/ProximaEPFL/proxima/issues/78)
-  // This is a workaround that will force the app to fetch the data from the server instead of the cache
-  // hence avoiding the issue of the posts not being updated in the overview
-  // We are basically disabling the cache globally
-  FirebaseFirestore.instance.settings = const Settings(
-    persistenceEnabled: false,
   );
 
   SystemChrome.setPreferredOrientations([

--- a/lib/models/database/post/post_location_firestore.dart
+++ b/lib/models/database/post/post_location_firestore.dart
@@ -6,13 +6,8 @@ class PostLocationFirestore {
   final GeoPoint geoPoint;
   final String geohash;
 
-  /// Do not change !
-  /// The [GeoFlutterFire] library that is used to perform the geo queries uses
-  /// hardcoded field name values in its implementation and does not provide
-  /// methods to automatically parse the point data. Thus we must manually specify
-  /// the field name for the geo point and the geo hash
-  static const String geoPointField = "geopoint"; // Do not change
-  static const String geohashField = "geohash"; // Do not change
+  static const String geoPointField = "geopoint";
+  static const String geohashField = "geohash";
 
   const PostLocationFirestore({
     required this.geoPoint,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   google_sign_in_mocks: ^0.3.0
   cloud_firestore: ^4.15.9
   fake_cloud_firestore: ^2.4.8
-  geoflutterfire2: ^2.3.15
+  geoflutterfire_plus: ^0.0.20
   geolocator: ^11.0.0
   mockito: ^5.4.4
   google_fonts: ^6.2.1

--- a/test/models/database/post/mock_post_data.dart
+++ b/test/models/database/post/mock_post_data.dart
@@ -1,5 +1,5 @@
 import "package:cloud_firestore/cloud_firestore.dart";
-import "package:geoflutterfire2/geoflutterfire2.dart";
+import "package:geoflutterfire_plus/geoflutterfire_plus.dart";
 import "package:proxima/models/database/post/post_data.dart";
 import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
@@ -13,13 +13,13 @@ class MockPostFirestore {
     GeoPoint location, {
     id = "post_id",
   }) {
-    final point = GeoFirePoint(location.latitude, location.longitude);
+    final point = GeoFirePoint(location);
 
     return PostFirestore(
       id: PostIdFirestore(value: id),
       location: PostLocationFirestore(
         geoPoint: location,
-        geohash: point.hash,
+        geohash: point.geohash,
       ),
       data: data,
     );

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -1,7 +1,7 @@
 import "package:cloud_firestore/cloud_firestore.dart";
 import "package:fake_cloud_firestore/fake_cloud_firestore.dart";
 import "package:flutter_test/flutter_test.dart";
-import "package:geoflutterfire2/geoflutterfire2.dart";
+import "package:geoflutterfire_plus/geoflutterfire_plus.dart";
 import "package:proxima/models/database/post/post_data.dart";
 import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
@@ -152,8 +152,7 @@ void main() {
 
     test("add post at location correctly", () async {
       const userPosition = GeoPoint(40, 20);
-      final userGeoFirePoint =
-          GeoFirePoint(userPosition.latitude, userPosition.longitude);
+      const userGeoFirePoint = GeoFirePoint(userPosition);
 
       final postData = MockPostFirestore.generatePostData(1).first;
 
@@ -167,7 +166,7 @@ void main() {
         id: PostIdFirestore(value: actualPosts.docs.first.id),
         location: PostLocationFirestore(
           geoPoint: userPosition,
-          geohash: userGeoFirePoint.hash,
+          geohash: userGeoFirePoint.geohash,
         ),
         data: postData,
       );
@@ -200,13 +199,9 @@ void main() {
           await postRepository.getNearPosts(userPosition, kmRadius);
 
       final expectedPosts = allPosts.where((element) {
-        final geoFirePoint = GeoFirePoint(
-          element.location.geoPoint.latitude,
-          element.location.geoPoint.longitude,
-        );
-        final distance = geoFirePoint.distance(
-          lat: userPosition.latitude,
-          lng: userPosition.longitude,
+        final geoFirePoint = GeoFirePoint(element.location.geoPoint);
+        final distance = geoFirePoint.distanceBetweenInKm(
+          geopoint: userPosition,
         );
         return distance <= kmRadius;
       }).toList();


### PR DESCRIPTION
Hello,
This PR aims to provide a proper fix to #78.
Indeed, a first fix was proposed in PR #116. 
But this implied that the overview was displaying a stream that was auto updated in real time.
After further discussions with the team, we determined that this wouldn't contribute to the user experience.
For instance, if the user is reading a post and that another is added near him, his scroll position might be offseted which can be anoying.
Thus, we chose to stay with a manual refresh for now.

In order to have a manual refresh, we need to be able to expose a `Future<List<PostFirestore>>` in `PostRepository` as previously while correcting the bug.
Technically speaking, this requires the underlying library to provide a `Future` implementation of geo queries. This feature is currently not supported by `GeoFlutterFire2`.

After some extensive researches, I found out that there exists a newer version of this library called **GeoFlutterFire plus**.
This library seems to be cleaner, maintained with thorough testing and it provides the functionnality that we described above.

Thus, in this PR, we do :
- Refactor the codebase to use **GeoFlutterFire plus**
- Use the `Future` implementation of **GeoFlutterFire plus** to get the nearby posts which fixes the bug #78
- Re-enable the firestore cache which was only a temporary fix provided in #79.


## Live testing
You can live test this fix as follows:
- Go into the overview page
- Add a post through the application
- Refresh the overview

With the presence of the bug, the new post wouldn't appear, but with this fix, you should be able to see it appear in the feed.

Thank you for reviewing this PR and I look forward to your feedback :+1: 



