### PR TITLE
Fix tests

### DIFF
--- a/test/mocks/data/firestore_post.dart
+++ b/test/mocks/data/firestore_post.dart
@@ -12,6 +12,8 @@ import "post_data.dart";
 
 /// Helper class to create mock post data to be used in tests
 class FirestorePostGenerator {
+  int _postId = 0;
+
   /// Create a [PostFirestore] with given data
   static PostFirestore createPostAt(
     PostData data,
@@ -38,15 +40,17 @@ class FirestorePostGenerator {
   }
 
   /// Create a [PostFirestore] with random data
-  static PostFirestore createUserPost(
+  PostFirestore createUserPost(
     UserIdFirestore userId,
     GeoPoint location,
   ) {
     final point = GeoPoint(location.latitude, location.longitude);
 
+    _postId += 1;
+
     return PostFirestore(
       id: PostIdFirestore(
-        value: DateTime.now().microsecondsSinceEpoch.toString(),
+        value: _postId.toString(),
       ),
       location: PostLocationFirestore(
         geoPoint: location,

--- a/test/mocks/data/firestore_post.dart
+++ b/test/mocks/data/firestore_post.dart
@@ -15,14 +15,19 @@ class FirestorePostGenerator {
   int _postId = 0;
 
   /// Create a [PostFirestore] with given data
-  static PostFirestore createPostAt(
+  PostFirestore createPostAt(
     PostData data,
     GeoPoint location, {
-    id = "post_id",
+    String? id,
   }) {
     final point = GeoFirePoint(location);
+
+    if (id == null) {
+      _postId += 1;
+    }
+
     return PostFirestore(
-      id: PostIdFirestore(value: id),
+      id: PostIdFirestore(value: id ?? _postId.toString()),
       location: PostLocationFirestore(
         geoPoint: location,
         geohash: point.geohash,
@@ -32,7 +37,7 @@ class FirestorePostGenerator {
   }
 
   /// Generate a [PostFirestore] at position [location], generating the post data
-  static PostFirestore generatePostAt(GeoPoint location) {
+  PostFirestore generatePostAt(GeoPoint location) {
     return createPostAt(
       PostDataGenerator.generatePostData(1).first,
       location,

--- a/test/mocks/data/firestore_post.dart
+++ b/test/mocks/data/firestore_post.dart
@@ -22,12 +22,10 @@ class FirestorePostGenerator {
   }) {
     final point = GeoFirePoint(location);
 
-    if (id == null) {
-      _postId += 1;
-    }
+    id ??= (_postId++).toString();
 
     return PostFirestore(
-      id: PostIdFirestore(value: id ?? _postId.toString()),
+      id: PostIdFirestore(value: id),
       location: PostLocationFirestore(
         geoPoint: location,
         geohash: point.geohash,

--- a/test/models/database/post/post_data_test.dart
+++ b/test/models/database/post/post_data_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(actualHash, expectedHash);
 
       const geoPoint = userPosition1;
-      final post = FirestorePostGenerator.createPostAt(data, geoPoint);
+      final post = FirestorePostGenerator().createPostAt(data, geoPoint);
       final expectedHash2 = Object.hash(post.id, post.location, post.data);
       final actualHash2 = post.hashCode;
       expect(actualHash2, expectedHash2);

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -109,7 +109,9 @@ void main() {
       const userPosition = userPosition1;
       final expectedPost = FirestorePostGenerator().generatePostAt(
         geoPointGenerator.createPostOnEdgeInsidePosition(
-            userPosition, kmRadius),
+          userPosition,
+          kmRadius,
+        ),
       );
 
       await setPostFirestore(expectedPost);
@@ -123,7 +125,9 @@ void main() {
       const userPosition = userPosition1;
       final expectedPost = FirestorePostGenerator().generatePostAt(
         geoPointGenerator.createPostOnEdgeOutsidePosition(
-            userPosition, kmRadius),
+          userPosition,
+          kmRadius,
+        ),
       );
 
       await setPostFirestore(expectedPost);

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -193,20 +193,17 @@ void main() {
     });
 
     test("Get simple user posts correctly", () async {
+      final generator = FirestorePostGenerator();
       const userId1 = UserIdFirestore(value: "user_id_1");
 
-      final postsData1 =
-          FirestorePostGenerator.createUserPost(userId1, userPosition2);
-      final postsData2 =
-          FirestorePostGenerator.createUserPost(userId1, userPosition3);
+      final postsData1 = generator.createUserPost(userId1, userPosition2);
+      final postsData2 = generator.createUserPost(userId1, userPosition3);
       await setPostsFirestore([postsData1, postsData2]);
 
       const userId2 = UserIdFirestore(value: "user_id_2");
 
-      final postsData3 =
-          FirestorePostGenerator.createUserPost(userId2, userPosition2);
-      final postsData4 =
-          FirestorePostGenerator.createUserPost(userId2, userPosition3);
+      final postsData3 = generator.createUserPost(userId2, userPosition2);
+      final postsData4 = generator.createUserPost(userId2, userPosition3);
       await setPostsFirestore([postsData3, postsData4]);
 
       final actualPosts1 = await postRepository.getUserPosts(userId1);

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -47,7 +47,7 @@ void main() {
       );
     });
 
-    final post = FirestorePostGenerator.generatePostAt(
+    final post = FirestorePostGenerator().generatePostAt(
       userPosition2,
     );
 
@@ -78,7 +78,7 @@ void main() {
 
     test("Get single nearby post correctly", () async {
       const userPosition = userPosition1;
-      final expectedPost = FirestorePostGenerator.generatePostAt(
+      final expectedPost = FirestorePostGenerator().generatePostAt(
         GeoPointGenerator().createNearbyPostPosition(userPosition),
       );
 
@@ -92,7 +92,7 @@ void main() {
     test("Post is not queried when far away", () async {
       const userPosition = userPosition1;
 
-      final expectedPost = FirestorePostGenerator.generatePostAt(
+      final expectedPost = FirestorePostGenerator().generatePostAt(
         GeoPointGenerator().createFarAwayPostPosition(userPosition, kmRadius),
       );
 
@@ -105,7 +105,7 @@ void main() {
 
     test("Post on edge (inside) is queried", () async {
       const userPosition = userPosition1;
-      final expectedPost = FirestorePostGenerator.generatePostAt(
+      final expectedPost = FirestorePostGenerator().generatePostAt(
         GeoPointGenerator()
             .createPostOnEdgeInsidePosition(userPosition, kmRadius),
       );
@@ -119,7 +119,7 @@ void main() {
 
     test("Post on edge (outside) is not queried", () async {
       const userPosition = userPosition1;
-      final expectedPost = FirestorePostGenerator.generatePostAt(
+      final expectedPost = FirestorePostGenerator().generatePostAt(
         GeoPointGenerator()
             .createPostOnEdgeOutsidePosition(userPosition, kmRadius),
       );
@@ -169,7 +169,7 @@ void main() {
       final postsData = PostDataGenerator.generatePostData(nbPosts);
 
       final allPosts = List.generate(nbPosts, (i) {
-        return FirestorePostGenerator.createPostAt(
+        return FirestorePostGenerator().createPostAt(
           postsData[i],
           pointList[i],
           id: "post_$i",

--- a/test/services/database/post_repository_test.dart
+++ b/test/services/database/post_repository_test.dart
@@ -15,6 +15,7 @@ void main() {
   group("Post Repository testing", () {
     late FakeFirebaseFirestore firestore;
     late PostRepositoryService postRepository;
+    late GeoPointGenerator geoPointGenerator;
 
     const kmRadius = 0.1;
 
@@ -45,6 +46,7 @@ void main() {
       postRepository = PostRepositoryService(
         firestore: firestore,
       );
+      geoPointGenerator = GeoPointGenerator();
     });
 
     final post = FirestorePostGenerator().generatePostAt(
@@ -79,7 +81,7 @@ void main() {
     test("Get single nearby post correctly", () async {
       const userPosition = userPosition1;
       final expectedPost = FirestorePostGenerator().generatePostAt(
-        GeoPointGenerator().createNearbyPostPosition(userPosition),
+        geoPointGenerator.createNearbyPostPosition(userPosition),
       );
 
       await setPostFirestore(expectedPost);
@@ -93,7 +95,7 @@ void main() {
       const userPosition = userPosition1;
 
       final expectedPost = FirestorePostGenerator().generatePostAt(
-        GeoPointGenerator().createFarAwayPostPosition(userPosition, kmRadius),
+        geoPointGenerator.createFarAwayPostPosition(userPosition, kmRadius),
       );
 
       await setPostFirestore(expectedPost);
@@ -106,8 +108,8 @@ void main() {
     test("Post on edge (inside) is queried", () async {
       const userPosition = userPosition1;
       final expectedPost = FirestorePostGenerator().generatePostAt(
-        GeoPointGenerator()
-            .createPostOnEdgeInsidePosition(userPosition, kmRadius),
+        geoPointGenerator.createPostOnEdgeInsidePosition(
+            userPosition, kmRadius),
       );
 
       await setPostFirestore(expectedPost);
@@ -120,8 +122,8 @@ void main() {
     test("Post on edge (outside) is not queried", () async {
       const userPosition = userPosition1;
       final expectedPost = FirestorePostGenerator().generatePostAt(
-        GeoPointGenerator()
-            .createPostOnEdgeOutsidePosition(userPosition, kmRadius),
+        geoPointGenerator.createPostOnEdgeOutsidePosition(
+            userPosition, kmRadius),
       );
 
       await setPostFirestore(expectedPost);
@@ -160,7 +162,7 @@ void main() {
       const nbPostsInRange = 7;
 
       // The 7 first posts are under 100m away from the user and are the ones expected
-      final pointList = GeoPointGenerator().generatePositions(
+      final pointList = geoPointGenerator.generatePositions(
         userPosition0,
         nbPostsInRange,
         nbPosts - nbPostsInRange,

--- a/test/viewmodels/home_view_model_unit_test.dart
+++ b/test/viewmodels/home_view_model_unit_test.dart
@@ -79,7 +79,8 @@ void main() {
             ),
           )
           .toList()[0];
-      final post = FirestorePostGenerator.createPostAt(postData, userPosition0);
+      final post =
+          FirestorePostGenerator().createPostAt(postData, userPosition0);
 
       when(userRepository.getUser(post.data.ownerId)).thenAnswer(
         (_) async => owner,
@@ -133,7 +134,7 @@ void main() {
             .toList();
 
         final posts = postsData.map((data) {
-          return FirestorePostGenerator.createPostAt(data, userPosition0);
+          return FirestorePostGenerator().createPostAt(data, userPosition0);
         }).toList();
 
         final expectedPosts = postsData.map((data) {
@@ -190,7 +191,7 @@ void main() {
         );
 
         final posts = postsData.map((data) {
-          return FirestorePostGenerator.createPostAt(data, userPosition0);
+          return FirestorePostGenerator().createPostAt(data, userPosition0);
         }).toList();
 
         final expectedPosts = postsData.mapIndexed(
@@ -262,7 +263,8 @@ void main() {
             ),
           )
           .toList()[0];
-      final post = FirestorePostGenerator.createPostAt(postData, userPosition0);
+      final post =
+          FirestorePostGenerator().createPostAt(postData, userPosition0);
 
       final expectedPosts = [
         PostOverview(

--- a/test/views/pages/new_post/new_post_test.dart
+++ b/test/views/pages/new_post/new_post_test.dart
@@ -19,7 +19,7 @@ void main() {
   late MockPostRepositoryService postRepository;
   late MockGeoLocationService geoLocationService;
 
-  const timeDeltaMils = 500;
+  const timeDeltaMils = 5000;
 
   setUp(() async {
     setupFirebaseAuthMocks();


### PR DESCRIPTION
Fixes #156.

This PR fixes some tests, which failed in a random-looking fashion.
1) 1d58e3ac1fbe6d507d46e61133e38a6b6b65f2bf's fix is thanks to @yoannLafore, who found the problem. Two posts could have the same id, and thus replace one another in the database. This failed consistently on some computers, but not on others.
2) c6ed8db2916fa65a48d585a89bca9f2897b9e313's fix simply increases the allowed error margin. It was previously too small, resulting in a rare, but non-deterministic, fail.

While reviewing, I want to particularly attract your attention to 9c46f5492a92c962bad80d9fe05be11e3373b7a9. This is done just to uniformise with the first fix. This may not have its place in this PR, and it may just be complicating everything. Don't hesitate to tell me if you want me to revert it.