### PR TITLE
Post creation and navigation refreshes home feed

### DIFF
--- a/lib/viewmodels/home_view_model.dart
+++ b/lib/viewmodels/home_view_model.dart
@@ -9,7 +9,7 @@ import "package:proxima/services/geolocation_service.dart";
 /// It fetches the posts from the database and returns a list of
 /// (postId: [PostIdFirestore], postOverview: [PostOverview]) objects to be displayed.
 /// These represent the overview data to be displayed associated to the corresponding post id.
-class HomeViewModel extends AsyncNotifier<List<PostOverview>> {
+class HomeViewModel extends AutoDisposeAsyncNotifier<List<PostOverview>> {
   HomeViewModel();
 
   static const kmPostRadius = 0.1;
@@ -66,6 +66,6 @@ class HomeViewModel extends AsyncNotifier<List<PostOverview>> {
 }
 
 final postOverviewProvider =
-    AsyncNotifierProvider<HomeViewModel, List<PostOverview>>(
+    AutoDisposeAsyncNotifierProvider<HomeViewModel, List<PostOverview>>(
   () => HomeViewModel(),
 );

--- a/lib/viewmodels/new_post_view_model.dart
+++ b/lib/viewmodels/new_post_view_model.dart
@@ -4,6 +4,7 @@ import "package:proxima/models/database/post/post_data.dart";
 import "package:proxima/models/ui/new_post_state.dart";
 import "package:proxima/services/database/post_repository_service.dart";
 import "package:proxima/services/geolocation_service.dart";
+import "package:proxima/viewmodels/home_view_model.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
 
 class NewPostViewModel extends AutoDisposeAsyncNotifier<NewPostState> {
@@ -69,6 +70,9 @@ class NewPostViewModel extends AutoDisposeAsyncNotifier<NewPostState> {
     );
 
     await postRepository.addPost(post, currPosition);
+
+    // Refresh the home feed after post creation
+    ref.read(postOverviewProvider.notifier).refresh();
 
     return NewPostState(
       titleError: null,

--- a/test/end2end/app_test.dart
+++ b/test/end2end/app_test.dart
@@ -208,10 +208,6 @@ Future<void> createPost(WidgetTester tester) async {
   await tester.drag(find.byType(PostFeed), const Offset(0, 500));
   await tester.pumpAndSettle();
 
-  final refreshButton = find.byKey(PostFeed.refreshButtonKey);
-  await tester.tap(refreshButton);
-  await tester.pumpAndSettle();
-
   // Check that the post is displayed
   expect(find.text(postTitle), findsOneWidget);
   expect(find.text(postDescription), findsOneWidget);

--- a/test/mocks/overrides/override_home_view_model.dart
+++ b/test/mocks/overrides/override_home_view_model.dart
@@ -8,7 +8,7 @@ import "../data/post_overview.dart";
 /// This class is particularly useful for the UI tests where we want to expose
 /// particular data to the views.
 /// By default it exposes an empty list of [PostOverview] and does nothing on refresh.
-class MockHomeViewModel extends AsyncNotifier<List<PostOverview>>
+class MockHomeViewModel extends AutoDisposeAsyncNotifier<List<PostOverview>>
     implements HomeViewModel {
   final Future<List<PostOverview>> Function() _build;
   final Future<void> Function() _onRefresh;


### PR DESCRIPTION
## Post creation and navigation refreshes home feed

Fixes #187 

This PRs adds the necessary code to automatically refresh the home feed of posts on navigation and on post creation.

### Acceptance criteria

- When navigating from another page back to the home feed, the posts on the feed are refreshed.
- After coming back from the post creation page the home feed is refreshed (we see our new post right away, no need to manually refresh).