### PR TITLE
Challenge view model

### DIFF
--- a/lib/services/database/challenge_repository_service.dart
+++ b/lib/services/database/challenge_repository_service.dart
@@ -62,6 +62,11 @@ class ChallengeRepositoryService {
       return false;
     }
 
+    final challengeData = ChallengeData.fromDb(challengeSnap.data()!);
+    if (challengeData.isCompleted || challengeData.isExpired) {
+      return false;
+    }
+
     await _activeChallengesRef(userDocRef).doc(pid.value).update({
       ChallengeData.isCompletedField: true,
     });

--- a/lib/services/database/challenge_repository_service.dart
+++ b/lib/services/database/challenge_repository_service.dart
@@ -47,18 +47,26 @@ class ChallengeRepositoryService {
         .collection(ChallengeFirestore.pastChallengesSubCollectionName);
   }
 
-  /// Completes the challenge of the user with id [uid] on the post with id [pid]
-  Future<void> completeChallenge(
+  /// Completes the challenge of the user with id [uid] on the post with id [pid].
+  /// Returns true if the challenge is valid and was completed, and false otherwise.
+  Future<bool> completeChallenge(
     UserIdFirestore uid,
     PostIdFirestore pid,
   ) async {
     final userDocRef =
         _firestore.collection(UserFirestore.collectionName).doc(uid.value);
+    final challengeSnap =
+        await _activeChallengesRef(userDocRef).doc(pid.value).get();
+
+    if (!challengeSnap.exists) {
+      return false;
+    }
+
     await _activeChallengesRef(userDocRef).doc(pid.value).update({
       ChallengeData.isCompletedField: true,
     });
-
     await _userRepositoryService.addPoints(uid, soloChallengeReward);
+    return true;
   }
 
   /// Returns the active challenges of the user with id [uid] who is located at [pos].

--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -35,11 +35,16 @@ class ChallengeViewModel extends AsyncNotifier<List<ChallengeCardData>> {
         title: post.data.title,
         distance: distanceM,
         timeLeft: timeLeft.inHours,
-        reward: 500,
+        reward: ChallengeRepositoryService.soloChallengeReward,
       );
     });
 
     return Future.wait(uiChallenges);
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => build());
   }
 }
 

--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -1,5 +1,6 @@
 import "package:geoflutterfire_plus/geoflutterfire_plus.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/ui/challenge_card_data.dart";
 import "package:proxima/services/database/challenge_repository_service.dart";
 import "package:proxima/services/database/post_repository_service.dart";
@@ -25,18 +26,26 @@ class ChallengeViewModel extends AsyncNotifier<List<ChallengeCardData>> {
     Iterable<Future<ChallengeCardData>> uiChallenges =
         firestoreChallenges.map((challenge) async {
       final post = await postRepository.getPost(challenge.postId);
-      final double distanceKm = GeoFirePoint(currentPosition)
-          .distanceBetweenInKm(geopoint: post.location.geoPoint);
-      final int distanceM = (distanceKm * 1000).toInt();
-
       final timeLeft = challenge.data.expiresOn.toDate().difference(now);
 
-      return ChallengeCardData.solo(
-        title: post.data.title,
-        distance: distanceM,
-        timeLeft: timeLeft.inHours,
-        reward: ChallengeRepositoryService.soloChallengeReward,
-      );
+      if (!challenge.data.isCompleted) {
+        final double distanceKm = GeoFirePoint(currentPosition)
+            .distanceBetweenInKm(geopoint: post.location.geoPoint);
+        final int distanceM = (distanceKm * 1000).toInt();
+
+        return ChallengeCardData.solo(
+          title: post.data.title,
+          distance: distanceM,
+          timeLeft: timeLeft.inHours,
+          reward: ChallengeRepositoryService.soloChallengeReward,
+        );
+      } else {
+        return ChallengeCardData.soloFinished(
+          title: post.data.title,
+          timeLeft: timeLeft.inHours,
+          reward: ChallengeRepositoryService.soloChallengeReward,
+        );
+      }
     });
 
     return Future.wait(uiChallenges);

--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -6,8 +6,6 @@ import "package:proxima/services/database/post_repository_service.dart";
 import "package:proxima/services/geolocation_service.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
 
-// TODO: For now, this is duplicated code with the mock from the tests.
-// This will just be replaced when we implement a real view model anyway.
 class ChallengeViewModel extends AsyncNotifier<List<ChallengeCardData>> {
   @override
   Future<List<ChallengeCardData>> build() async {

--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -1,36 +1,47 @@
+import "package:geoflutterfire_plus/geoflutterfire_plus.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/ui/challenge_card_data.dart";
+import "package:proxima/services/database/challenge_repository_service.dart";
+import "package:proxima/services/database/post_repository_service.dart";
+import "package:proxima/services/geolocation_service.dart";
+import "package:proxima/viewmodels/login_view_model.dart";
 
 // TODO: For now, this is duplicated code with the mock from the tests.
 // This will just be replaced when we implement a real view model anyway.
 class ChallengeViewModel extends AsyncNotifier<List<ChallengeCardData>> {
   @override
   Future<List<ChallengeCardData>> build() async {
-    return const [
-      ChallengeCardData.solo(
-        title: "I hate UNIL, here's why",
-        distance: 700,
-        timeLeft: 27,
-        reward: 250,
-      ),
-      ChallengeCardData.solo(
-        title:
-            "John fell here lmaoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo",
-        distance: 3200,
-        timeLeft: 27,
-        reward: 400,
-      ),
-      ChallengeCardData.group(
-        title: "I'm moving out",
-        distance: 4000,
-        reward: 350,
-      ),
-      ChallengeCardData.soloFinished(
-        title: "What a view!",
-        timeLeft: 27,
-        reward: 200,
-      ),
-    ];
+    final geoLocationService = ref.watch(geoLocationServiceProvider);
+    final challengeRepository = ref.watch(challengeRepositoryServiceProvider);
+
+    final currentPosition = await geoLocationService.getCurrentPosition();
+    final currentUser = ref.watch(uidProvider);
+
+    final firestoreChallenges = await challengeRepository.getChallenges(
+      currentUser!,
+      currentPosition,
+    );
+
+    final postRepository = ref.watch(postRepositoryProvider);
+    final now = DateTime.now();
+    Iterable<Future<ChallengeCardData>> uiChallenges =
+        firestoreChallenges.map((challenge) async {
+      final post = await postRepository.getPost(challenge.postId);
+      final double distanceKm = GeoFirePoint(currentPosition)
+          .distanceBetweenInKm(geopoint: post.location.geoPoint);
+      final int distanceM = (distanceKm * 1000).toInt();
+
+      final timeLeft = challenge.data.expiresOn.toDate().difference(now);
+
+      return ChallengeCardData.solo(
+        title: post.data.title,
+        distance: distanceM,
+        timeLeft: timeLeft.inHours,
+        reward: 500,
+      );
+    });
+
+    return Future.wait(uiChallenges);
   }
 }
 

--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -55,6 +55,14 @@ class ChallengeViewModel extends AsyncNotifier<List<ChallengeCardData>> {
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() => build());
   }
+
+  Future<void> completeChallenge(PostIdFirestore pid) async {
+    final currentUser = ref.read(uidProvider);
+    final challengeRepository = ref.read(challengeRepositoryServiceProvider);
+
+    await challengeRepository.completeChallenge(currentUser!, pid);
+    await refresh();
+  }
 }
 
 final challengeProvider =

--- a/lib/views/home_content/challenge/challenge_list.dart
+++ b/lib/views/home_content/challenge/challenge_list.dart
@@ -14,9 +14,13 @@ class ChallengeList extends ConsumerWidget {
     return CircularValue(
       value: asyncChallenges,
       builder: (context, challenges) {
-        return ListView(
-          children:
-              challenges.map((challenge) => ChallengeCard(challenge)).toList(),
+        return RefreshIndicator(
+          onRefresh: () => ref.read(challengeProvider.notifier).refresh(),
+          child: ListView(
+            children: challenges
+                .map((challenge) => ChallengeCard(challenge))
+                .toList(),
+          ),
         );
       },
     );

--- a/lib/views/home_content/feed/post_card/post_card.dart
+++ b/lib/views/home_content/feed/post_card/post_card.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/ui/post_overview.dart";
-
+import "package:proxima/viewmodels/challenge_view_model.dart";
 import "package:proxima/views/home_content/feed/post_card/comment_widget.dart";
 import "package:proxima/views/home_content/feed/post_card/user_bar_widget.dart";
 import "package:proxima/views/home_content/feed/post_card/votes_widget.dart";
@@ -9,7 +10,7 @@ import "package:proxima/views/navigation/routes.dart";
 /// This widget is used to display the post card in the home feed.
 /// It contains the post title, description, votes, comments
 /// and the user (profile picture and username).
-class PostCard extends StatelessWidget {
+class PostCard extends ConsumerWidget {
   static const postCardKey = Key("postCard");
   static const postCardTitleKey = Key("postCardTitle");
   static const postCardDescriptionKey = Key("postCardDescription");
@@ -24,12 +25,13 @@ class PostCard extends StatelessWidget {
     required this.postOverview,
   });
 
-  void _onPostSelect(BuildContext context, PostOverview post) {
+  void _onPostSelect(BuildContext context, PostOverview post, WidgetRef ref) {
     Navigator.pushNamed(context, Routes.post.name, arguments: post);
+    ref.read(challengeProvider.notifier).completeChallenge(post.postId);
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final postBody = ListTile(
       title: Text(
         key: postCardTitleKey,
@@ -58,7 +60,7 @@ class PostCard extends StatelessWidget {
             customBorder: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(20),
             ),
-            onTap: () => _onPostSelect(context, postOverview),
+            onTap: () => _onPostSelect(context, postOverview, ref),
             child: CommentWidget(
               key: postCardCommentsKey,
               commentNumber: postOverview.commentNumber,
@@ -73,7 +75,7 @@ class PostCard extends StatelessWidget {
       key: postCardKey,
       clipBehavior: Clip.hardEdge,
       child: InkWell(
-        onTap: () => _onPostSelect(context, postOverview),
+        onTap: () => _onPostSelect(context, postOverview, ref),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/test/end2end/app_test.dart
+++ b/test/end2end/app_test.dart
@@ -5,6 +5,7 @@ import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:mockito/mockito.dart";
 import "package:proxima/main.dart";
+import "package:proxima/services/database/challenge_repository_service.dart";
 import "package:proxima/services/database/post_repository_service.dart";
 import "package:proxima/services/database/user_repository_service.dart";
 import "package:proxima/services/geolocation_service.dart";
@@ -27,6 +28,7 @@ void main() {
   late FakeFirebaseFirestore fakeFireStore;
   late PostRepositoryService postRepo;
   late UserRepositoryService userRepo;
+  late ChallengeRepositoryService challengeRepo;
 
   MockGeoLocationService geoLocationService = MockGeoLocationService();
   const GeoPoint testLocation = userPosition0;
@@ -38,6 +40,11 @@ void main() {
     postRepo = PostRepositoryService(firestore: fakeFireStore);
     userRepo = UserRepositoryService(
       firestore: fakeFireStore,
+    );
+    challengeRepo = ChallengeRepositoryService(
+      firestore: fakeFireStore,
+      postRepositoryService: postRepo,
+      userRepositoryService: userRepo,
     );
     when(geoLocationService.getCurrentPosition()).thenAnswer(
       (_) => Future.value(testLocation),
@@ -54,6 +61,7 @@ void main() {
           userRepositoryProvider.overrideWithValue(userRepo),
           geoLocationServiceProvider.overrideWithValue(geoLocationService),
           postRepositoryProvider.overrideWithValue(postRepo),
+          challengeRepositoryServiceProvider.overrideWithValue(challengeRepo),
         ],
         child: const ProximaApp(),
       ),

--- a/test/mocks/data/firestore_challenge.dart
+++ b/test/mocks/data/firestore_challenge.dart
@@ -1,0 +1,31 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:proxima/models/database/challenge/challenge_firestore.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/models/database/user/user_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+
+import "challenge_data.dart";
+
+class FirestoreChallengeGenerator {
+  int _id = 0;
+
+  ChallengeFirestore generate(bool done, Duration extra) {
+    final data = ChallengeGenerator.generate(done, extra);
+    final id = PostIdFirestore(value: (_id++).toString());
+    return ChallengeFirestore(postId: id, data: data);
+  }
+}
+
+Future<void> setChallenge(
+  FirebaseFirestore firestore,
+  ChallengeFirestore challenge,
+  UserIdFirestore uid,
+) async {
+  final challengeRef = firestore
+      .collection(UserFirestore.collectionName)
+      .doc(uid.value)
+      .collection(ChallengeFirestore.subCollectionName)
+      .doc(challenge.postId.value);
+
+  await challengeRef.set(challenge.data.toDbData());
+}

--- a/test/mocks/data/firestore_user.dart
+++ b/test/mocks/data/firestore_user.dart
@@ -42,3 +42,11 @@ class FirestoreUserGenerator {
     }).toList();
   }
 }
+
+Future<void> setUserFirestore(
+    FirebaseFirestore firestore, UserFirestore user) async {
+  await firestore
+      .collection(UserFirestore.collectionName)
+      .doc(user.uid.value)
+      .set(user.data.toDbData());
+}

--- a/test/mocks/data/firestore_user.dart
+++ b/test/mocks/data/firestore_user.dart
@@ -43,8 +43,10 @@ class FirestoreUserGenerator {
   }
 }
 
-Future<void> setUserFirestore(FirebaseFirestore firestore,
-    UserFirestore user,) async {
+Future<void> setUserFirestore(
+  FirebaseFirestore firestore,
+  UserFirestore user,
+) async {
   await firestore
       .collection(UserFirestore.collectionName)
       .doc(user.uid.value)

--- a/test/mocks/data/firestore_user.dart
+++ b/test/mocks/data/firestore_user.dart
@@ -43,8 +43,8 @@ class FirestoreUserGenerator {
   }
 }
 
-Future<void> setUserFirestore(
-    FirebaseFirestore firestore, UserFirestore user) async {
+Future<void> setUserFirestore(FirebaseFirestore firestore,
+    UserFirestore user,) async {
   await firestore
       .collection(UserFirestore.collectionName)
       .doc(user.uid.value)

--- a/test/mocks/overrides/override_challenges_view_model.dart
+++ b/test/mocks/overrides/override_challenges_view_model.dart
@@ -1,4 +1,5 @@
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/ui/challenge_card_data.dart";
 import "package:proxima/viewmodels/challenge_view_model.dart";
 
@@ -10,6 +11,12 @@ class MockChallengeViewModel extends AsyncNotifier<List<ChallengeCardData>>
   Future<List<ChallengeCardData>> build() async {
     return mockChallengeList;
   }
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<void> completeChallenge(PostIdFirestore pid) async {}
 }
 
 final mockChallengeOverride = [

--- a/test/mocks/providers/provider_homepage.dart
+++ b/test/mocks/providers/provider_homepage.dart
@@ -3,6 +3,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/views/navigation/routes.dart";
 import "package:proxima/views/pages/home/home_page.dart";
 
+import "../overrides/override_challenges_view_model.dart";
 import "../overrides/override_home_view_model.dart";
 
 const homePageApp = MaterialApp(
@@ -16,7 +17,7 @@ final emptyHomePageProvider = ProviderScope(
 );
 
 final nonEmptyHomePageProvider = ProviderScope(
-  overrides: mockNonEmptyHomeViewModelOverride,
+  overrides: [...mockNonEmptyHomeViewModelOverride, ...mockChallengeOverride],
   child: homePageApp,
 );
 

--- a/test/services/database/challenge_repository_test.dart
+++ b/test/services/database/challenge_repository_test.dart
@@ -8,6 +8,7 @@ import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/database/user/user_firestore.dart";
 import "package:proxima/services/database/challenge_repository_service.dart";
 import "package:proxima/services/database/post_repository_service.dart";
+import "package:proxima/services/database/user_repository_service.dart";
 
 import "../../mocks/data/challenge_data.dart";
 import "../../mocks/data/firestore_post.dart";
@@ -19,13 +20,16 @@ void main() {
   late FakeFirebaseFirestore firestore;
   late PostRepositoryService postRepository;
   late ChallengeRepositoryService challengeRepository;
+  late UserRepositoryService userRepository;
 
   setUp(() async {
     firestore = FakeFirebaseFirestore();
     postRepository = PostRepositoryService(firestore: firestore);
+    userRepository = UserRepositoryService(firestore: firestore);
     challengeRepository = ChallengeRepositoryService(
       firestore: firestore,
       postRepositoryService: postRepository,
+      userRepositoryService: userRepository,
     );
   });
 
@@ -219,6 +223,7 @@ void main() {
       final challenges = await challengeRepository.getChallenges(uid, userPos);
       expect(challenges.length, 1);
 
+      setUserFirestore(firestore, testingUserFirestore);
       final challenge = challenges.first;
       expect(challenge.data.isCompleted, false);
       await challengeRepository.completeChallenge(

--- a/test/viewmodels/challenge_view_model_integration_test.dart
+++ b/test/viewmodels/challenge_view_model_integration_test.dart
@@ -1,0 +1,117 @@
+import "package:fake_cloud_firestore/fake_cloud_firestore.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:mockito/mockito.dart";
+import "package:proxima/services/database/challenge_repository_service.dart";
+import "package:proxima/services/database/post_repository_service.dart";
+import "package:proxima/services/database/user_repository_service.dart";
+import "package:proxima/services/geolocation_service.dart";
+import "package:proxima/viewmodels/challenge_view_model.dart";
+import "package:proxima/viewmodels/login_view_model.dart";
+
+import "../mocks/data/firestore_challenge.dart";
+import "../mocks/data/firestore_post.dart";
+import "../mocks/data/firestore_user.dart";
+import "../mocks/data/geopoint.dart";
+import "../mocks/services/mock_geo_location_service.dart";
+
+void main() {
+  late MockGeoLocationService geoLocationService;
+  late FakeFirebaseFirestore fakeFireStore;
+
+  late UserRepositoryService userRepo;
+  late PostRepositoryService postRepo;
+  late ChallengeRepositoryService challengeRepo;
+
+  late ProviderContainer container;
+
+  setUp(() async {
+    fakeFireStore = FakeFirebaseFirestore();
+    geoLocationService = MockGeoLocationService();
+
+    userRepo = UserRepositoryService(
+      firestore: fakeFireStore,
+    );
+    postRepo = PostRepositoryService(
+      firestore: fakeFireStore,
+    );
+    challengeRepo = ChallengeRepositoryService(
+      firestore: fakeFireStore,
+      userRepositoryService: userRepo,
+      postRepositoryService: postRepo,
+    );
+
+    container = ProviderContainer(
+      overrides: [
+        geoLocationServiceProvider.overrideWithValue(geoLocationService),
+        userRepositoryProvider.overrideWithValue(userRepo),
+        postRepositoryProvider.overrideWithValue(postRepo),
+        challengeRepositoryServiceProvider.overrideWithValue(challengeRepo),
+        uidProvider.overrideWithValue(testingUserFirestoreId),
+      ],
+    );
+
+    when(geoLocationService.getCurrentPosition()).thenAnswer(
+      (_) async => userPosition1,
+    );
+  });
+
+  test("No challenges are returned when the database is empty", () async {
+    final challenges = await container.read(challengeProvider.future);
+    expect(challenges, isEmpty);
+  });
+
+  test("Active challenge is transformed correctly", () async {
+    const extraTime = Duration(hours: 3);
+    final challengeGenerator = FirestoreChallengeGenerator();
+    final postGenerator = FirestorePostGenerator();
+
+    final post = postGenerator.generatePostAt(
+      userPosition1,
+    ); // the challenge is added by hand, so we can use the user position
+    await setPostFirestore(post, fakeFireStore);
+
+    final challenge = challengeGenerator.generate(false, extraTime);
+    await setChallenge(fakeFireStore, challenge, testingUserFirestoreId);
+
+    final challenges = await container.read(challengeProvider.future);
+    expect(challenges.length, 1);
+
+    final uiChallenge = challenges.first;
+    expect(uiChallenge.distance, 0);
+    expect(
+      uiChallenge.timeLeft,
+      anyOf(2, 3),
+    ); // 3 hours - 1 second or 3 hours - 0 seconds (we can't bet on the time of the above execution)
+    expect(uiChallenge.isFinished, false);
+    expect(uiChallenge.reward, ChallengeRepositoryService.soloChallengeReward);
+    expect(uiChallenge.title, post.data.title);
+  });
+
+  test("Completed challenge is transformed correctly", () async {
+    const extraTime = Duration(hours: 3);
+    final challengeGenerator = FirestoreChallengeGenerator();
+    final postGenerator = FirestorePostGenerator();
+
+    final post = postGenerator.generatePostAt(
+      userPosition1,
+    ); // the challenge is added by hand, so we can use the user position
+    await setPostFirestore(post, fakeFireStore);
+
+    final challenge = challengeGenerator.generate(true, extraTime);
+    await setChallenge(fakeFireStore, challenge, testingUserFirestoreId);
+
+    final challenges = await container.read(challengeProvider.future);
+    expect(challenges.length, 1);
+
+    final uiChallenge = challenges.first;
+    expect(uiChallenge.distance, null);
+    expect(
+      uiChallenge.timeLeft,
+      anyOf(2, 3),
+    ); // 3 hours - 1 second or 3 hours - 0 seconds (we can't bet on the time of the above execution)
+    expect(uiChallenge.isFinished, true);
+    expect(uiChallenge.reward, ChallengeRepositoryService.soloChallengeReward);
+    expect(uiChallenge.title, post.data.title);
+  });
+}


### PR DESCRIPTION
This PR addresses #173 

It adds the challenge view-model, showing updated challenges in the challenge view. It is possible to complete challenges by clicking on the post in the feed. Completing a challenge shows it as completed in the challenge view and awards 500 points.

I have modified `completeChallenge` method the challenge repository to only update the challenge document and add points if the challenge is actually valid, not completed and not expired. It whether everything went well or not. This can later be used to decide whether to show a message if points were awarded.

**Emulator Testing**: It is possible to test the functionality by hand in the emulator. Keep in mind that challenges are naturally updated only once per day, so you might want to tweak them by hand in the database while testing. You will also need to travel to the challenges, which you can again do by finding the posts in the database and changing the position of your emulator. The id of a challenge is the id of the post associated with it. As a reminder, challenges are drawn from posts that are between 500m and 3km of the current position.