### PR TITLE
Fix challenge repository crash when no available challenge

### DIFF
--- a/lib/services/database/challenge_repository_service.dart
+++ b/lib/services/database/challenge_repository_service.dart
@@ -144,6 +144,12 @@ class ChallengeRepositoryService {
 
     final Iterable<PostIdFirestore> possiblePosts =
         await _inRangeUnsortedPosts(pos, excludedUser);
+
+    // The whereIn argument of the where method crashed
+    // if the query is empty for the real firestore. This
+    // cannot be tested with the mock firestore.
+    if (possiblePosts.isEmpty) return;
+
     final Iterable<String> possiblePostsStringIds =
         possiblePosts.map((post) => post.value);
 

--- a/lib/views/home_content/challenge/challenge_list.dart
+++ b/lib/views/home_content/challenge/challenge_list.dart
@@ -12,7 +12,7 @@ class ChallengeList extends ConsumerWidget {
     final asyncChallenges = ref.watch(challengeProvider);
 
     Widget emptyChallenge = const Center(
-      child: Text("No challenges available here"),
+      child: Text("No challenge available here!"),
     );
 
     return CircularValue(

--- a/lib/views/home_content/challenge/challenge_list.dart
+++ b/lib/views/home_content/challenge/challenge_list.dart
@@ -11,16 +11,22 @@ class ChallengeList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncChallenges = ref.watch(challengeProvider);
 
+    Widget emptyChallenge = const Center(
+      child: Text("No challenges available here"),
+    );
+
     return CircularValue(
       value: asyncChallenges,
       builder: (context, challenges) {
         return RefreshIndicator(
           onRefresh: () => ref.read(challengeProvider.notifier).refresh(),
-          child: ListView(
-            children: challenges
-                .map((challenge) => ChallengeCard(challenge))
-                .toList(),
-          ),
+          child: (challenges.isEmpty)
+              ? emptyChallenge
+              : ListView(
+                  children: challenges
+                      .map((challenge) => ChallengeCard(challenge))
+                      .toList(),
+                ),
         );
       },
     );

--- a/lib/views/home_content/challenge/challenge_list.dart
+++ b/lib/views/home_content/challenge/challenge_list.dart
@@ -20,7 +20,7 @@ class ChallengeList extends ConsumerWidget {
       builder: (context, challenges) {
         return RefreshIndicator(
           onRefresh: () => ref.read(challengeProvider.notifier).refresh(),
-          child: (challenges.isEmpty)
+          child: challenges.isEmpty
               ? emptyChallenge
               : ListView(
                   children: challenges


### PR DESCRIPTION
Fixes #216.

This fixes a crash from the challenge when there is no available challenge. It crashes [here](https://github.com/firebase/flutterfire/blob/953bf929bf19e7bbb3564c69901f5a4fca5fc981/packages/cloud_firestore/cloud_firestore/lib/src/query.dart#L734) in the real firestore. This cannot be tested with our mock firestore, since [this behaviour is not emulated in it](https://github.com/atn832/fake_cloud_firestore/blob/46fd92164bbc543534c3fdd7fe390c535bbd2847/lib/src/mock_query.dart#L230). In fact, we already had a test that checked the case where there is no challenge in-range, `challenge_repository_test.dart`:"Challenge range works"; so no regression test can be done.

Acceptance criteria:
- [x] the challenge page must not crash when there is no challenge
