### PR TITLE
Add comment viewmodel

### DIFF
--- a/lib/models/ui/new_comment_state.dart
+++ b/lib/models/ui/new_comment_state.dart
@@ -1,0 +1,24 @@
+/// Represent the state of the new comment form
+/// It contains the content error message (null if there is no error)
+/// and a flag to indicate if the comment was posted
+class NewCommentState {
+  final String? contentError;
+  final bool posted;
+
+  NewCommentState({
+    required this.contentError,
+    required this.posted,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    return other is NewCommentState &&
+        other.contentError == contentError &&
+        other.posted == posted;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(contentError, posted);
+  }
+}

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -12,7 +12,7 @@ import "package:proxima/viewmodels/login_view_model.dart";
 /// post id [PostIdFirestore] is provided as an argument.
 class NewCommentViewModel
     extends AutoDisposeFamilyAsyncNotifier<NewCommentState, PostIdFirestore> {
-  static const String _contentError = "Please fill out your comment";
+  static const String contentEmptyError = "Please fill out your comment";
 
   @override
   Future<NewCommentState> build(PostIdFirestore arg) async {
@@ -26,7 +26,7 @@ class NewCommentViewModel
     if (content.isEmpty) {
       state = AsyncData(
         NewCommentState(
-          contentError: _contentError,
+          contentError: contentEmptyError,
           posted: false,
         ),
       );

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -77,3 +77,8 @@ class NewCommentViewModel
     return state.value!;
   }
 }
+
+final newCommentStateProvider = AsyncNotifierProvider.autoDispose
+    .family<NewCommentViewModel, NewCommentState, PostIdFirestore>(
+  () => NewCommentViewModel(),
+);

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -8,6 +8,8 @@ import "package:proxima/models/ui/new_comment_state.dart";
 import "package:proxima/services/database/comment_repository_service.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
 
+/// The view model for adding a new comment to a post whose
+/// post id [PostIdFirestore] is provided as an argument.
 class NewCommentViewModel
     extends AutoDisposeFamilyAsyncNotifier<NewCommentState, PostIdFirestore> {
   static const String _contentError = "Please enter a coment";

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -12,7 +12,7 @@ import "package:proxima/viewmodels/login_view_model.dart";
 /// post id [PostIdFirestore] is provided as an argument.
 class NewCommentViewModel
     extends AutoDisposeFamilyAsyncNotifier<NewCommentState, PostIdFirestore> {
-  static const String _contentError = "Please enter a coment";
+  static const String _contentError = "Please fill out your comment";
 
   @override
   Future<NewCommentState> build(PostIdFirestore arg) async {

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -37,6 +37,12 @@ class NewCommentViewModel
     return true;
   }
 
+  /// Resets the state to be ready for adding a new comment.
+  Future<void> reset() async {
+    ref.invalidateSelf();
+    await future;
+  }
+
   /// Verifies that the content is not empty, then adds a new comment to the database.
   /// If the content is empty, the state is updated with the appropriate error message.
   /// If the comment is successfully added, the state is updated with the posted flag set to true.

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -1,0 +1,79 @@
+import "dart:async";
+
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/comment/comment_data.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/models/ui/new_comment_state.dart";
+import "package:proxima/services/database/comment_repository_service.dart";
+import "package:proxima/viewmodels/login_view_model.dart";
+
+class NewCommentViewModel
+    extends AutoDisposeFamilyAsyncNotifier<NewCommentState, PostIdFirestore> {
+  static const String _contentError = "Please enter a coment";
+
+  @override
+  Future<NewCommentState> build(PostIdFirestore arg) async {
+    return NewCommentState(contentError: null, posted: false);
+  }
+
+  /// Validates that the content is not empty.
+  /// If it is empty, the state is updated with the appropriate error message.
+  /// Returns true if the content is not empty, false otherwise.
+  bool validate(String content) {
+    if (content.isEmpty) {
+      state = AsyncData(
+        NewCommentState(
+          contentError: _contentError,
+          posted: false,
+        ),
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Verifies that the content is not empty, then adds a new comment to the database.
+  /// If the content is empty, the state is updated with the appropriate error message.
+  /// If the comment is successfully added, the state is updated with the posted flag set to true.
+  Future<void> tryAddComment(String content) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() => _tryAddComment(content));
+  }
+
+  Future<NewCommentState> _tryAddComment(String content) async {
+    final currentUserId = ref.read(uidProvider);
+    if (currentUserId == null) {
+      throw Exception("User must be logged in before creating a comment");
+    }
+
+    if (!validate(content)) {
+      // not loading or error since validation failed and wrote to the state
+      return state.value!;
+    }
+
+    // The parent post id is gotten from the family argument
+    final postId = arg;
+
+    final commentData = CommentData(
+      content: content,
+      ownerId: currentUserId,
+      publicationTime: Timestamp.now(),
+      voteScore: 0,
+    );
+
+    final commentRepository = ref.read(commentRepositoryProvider);
+    await commentRepository.addComment(postId, commentData);
+
+    state = AsyncData(
+      NewCommentState(
+        contentError: null,
+        posted: true,
+      ),
+    );
+
+    return state.value!;
+  }
+}

--- a/lib/viewmodels/new_comment_view_model.dart
+++ b/lib/viewmodels/new_comment_view_model.dart
@@ -40,9 +40,11 @@ class NewCommentViewModel
   /// Verifies that the content is not empty, then adds a new comment to the database.
   /// If the content is empty, the state is updated with the appropriate error message.
   /// If the comment is successfully added, the state is updated with the posted flag set to true.
-  Future<void> tryAddComment(String content) async {
+  /// Returns true if the comment was successfully added, false otherwise.
+  Future<bool> tryAddComment(String content) async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() => _tryAddComment(content));
+    return state.value?.posted ?? false;
   }
 
   Future<NewCommentState> _tryAddComment(String content) async {

--- a/lib/views/pages/post/post_page.dart
+++ b/lib/views/pages/post/post_page.dart
@@ -83,10 +83,11 @@ class PostPage extends HookConsumerWidget {
           padding:
               // This is necessary to prevent the keyboard from covering the bottom bar
               EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-          child: const BottomBarAddComment(
+          child: BottomBarAddComment(
             key: bottomBarAddCommentKey,
             //TODO: Replace with actual username
             currentDisplayName: "Username",
+            parentPostId: postOverview.postId,
           ),
         ),
       ],

--- a/lib/views/pages/post/post_page_widget/bottom_bar_add_comment.dart
+++ b/lib/views/pages/post/post_page_widget/bottom_bar_add_comment.dart
@@ -1,7 +1,13 @@
 import "package:flutter/material.dart";
+import "package:flutter_hooks/flutter_hooks.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/utils/ui/circular_value.dart";
 import "package:proxima/utils/ui/user_avatar.dart";
+import "package:proxima/viewmodels/comment_view_model.dart";
+import "package:proxima/viewmodels/new_comment_view_model.dart";
 
-class BottomBarAddComment extends StatelessWidget {
+class BottomBarAddComment extends HookConsumerWidget {
   static const commentUserAvatarKey = Key("commentUserAvatar");
   static const addCommentTextFieldKey = Key("addCommentTextField");
   static const postCommentButtonKey = Key("postCommentButton");
@@ -9,51 +15,91 @@ class BottomBarAddComment extends StatelessWidget {
   static const _textFieldHintAddComment = "Add a comment";
 
   final String currentDisplayName;
+  final PostIdFirestore parentPostId;
 
   const BottomBarAddComment({
     super.key,
+    required this.parentPostId,
     required this.currentDisplayName,
   });
 
   @override
-  Widget build(BuildContext context) {
-    return Row(
-      // Align items to the start of the cross axis
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final contentController = useTextEditingController();
+
+    final asyncNewCommentState = ref.watch(
+      newCommentStateProvider(parentPostId),
+    );
+
+    return CircularValue(
+      value: asyncNewCommentState,
+      builder: (context, newCommentState) {
+        // The avatar of the current user on the left
+        final userAvatar = Padding(
           padding: const EdgeInsets.only(right: 8),
           child: UserAvatar(
             key: commentUserAvatarKey,
             displayName: currentDisplayName,
             radius: 22,
           ),
-        ),
-        const Expanded(
+        );
+
+        // The field in which the user can write a comment
+        final commentTextField = Expanded(
           child: TextField(
             key: addCommentTextFieldKey,
             minLines: 1,
             maxLines: 5,
             decoration: InputDecoration(
-              contentPadding: EdgeInsets.all(8),
-              border: OutlineInputBorder(),
+              contentPadding: const EdgeInsets.all(8),
+              border: const OutlineInputBorder(),
               hintText: _textFieldHintAddComment,
+              errorText: newCommentState.contentError,
             ),
+            controller: contentController,
           ),
-        ),
-        Align(
+        );
+
+        // The button to post the comment
+        final addCommentButton = Align(
           // Keeps the IconButton centered in the cross axis
           alignment: Alignment.center,
           child: IconButton(
             key: postCommentButtonKey,
             icon: const Icon(Icons.send),
-            onPressed: () {
-              //TODO: handle add comment
-              FocusManager.instance.primaryFocus?.unfocus();
+            onPressed: () async {
+              final newCommentViewModel = ref.read(
+                newCommentStateProvider(parentPostId).notifier,
+              );
+
+              final commentPosted = await newCommentViewModel.tryAddComment(
+                contentController.text,
+              );
+
+              // If the comment was posted, refresh the comment list
+              // and reset the new comment view model
+              if (commentPosted) {
+                await ref
+                    .read(commentListProvider(parentPostId).notifier)
+                    .refresh();
+                await newCommentViewModel.reset();
+                contentController.clear();
+                FocusManager.instance.primaryFocus?.unfocus();
+              }
             },
           ),
-        ),
-      ],
+        );
+
+        return Row(
+          // Align items to the start of the cross axis
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            userAvatar,
+            commentTextField,
+            addCommentButton,
+          ],
+        );
+      },
     );
   }
 }

--- a/test/mocks/providers/provider_post_page.dart
+++ b/test/mocks/providers/provider_post_page.dart
@@ -1,10 +1,15 @@
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/services/database/comment_repository_service.dart";
+import "package:proxima/viewmodels/login_view_model.dart";
 import "package:proxima/views/navigation/routes.dart";
 import "package:proxima/views/pages/post/post_page.dart";
 
 import "../data/post_overview.dart";
 import "../overrides/override_comment_view_model.dart";
+import "../overrides/override_firestore.dart";
+import "../services/mock_comment_repository_service.dart";
 
 // Create a post page with the first post from the testPosts list
 final postPage = MaterialApp(
@@ -23,3 +28,18 @@ final nonEmptyPostPageProvider = ProviderScope(
   overrides: mockNonEmptyCommentViewModelOverride,
   child: postPage,
 );
+
+ProviderScope postPageProvider(
+  MockCommentRepositoryService commentRepository,
+  UserIdFirestore userId,
+) {
+  return ProviderScope(
+    overrides: [
+      ...firebaseMocksOverrides,
+      ...mockEmptyCommentViewModelOverride,
+      commentRepositoryProvider.overrideWithValue(commentRepository),
+      uidProvider.overrideWithValue(userId),
+    ],
+    child: postPage,
+  );
+}

--- a/test/viewmodels/new_comment_view_model_integration_test.dart
+++ b/test/viewmodels/new_comment_view_model_integration_test.dart
@@ -1,0 +1,162 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:fake_cloud_firestore/fake_cloud_firestore.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/models/ui/new_comment_state.dart";
+import "package:proxima/services/database/comment_repository_service.dart";
+import "package:proxima/services/database/firestore_service.dart";
+import "package:proxima/viewmodels/login_view_model.dart";
+import "package:proxima/viewmodels/new_comment_view_model.dart";
+
+import "../mocks/data/comment_data.dart";
+import "../mocks/data/firestore_post.dart";
+import "../mocks/data/firestore_user.dart";
+import "../mocks/data/geopoint.dart";
+
+void main() {
+  group("Testing new comment view model", () {
+    late FakeFirebaseFirestore fakeFirestore;
+    late CommentDataGenerator commentDataGenerator;
+
+    late CommentRepositoryService commentRepository;
+    late AutoDisposeFamilyAsyncNotifierProvider<NewCommentViewModel,
+        NewCommentState, PostIdFirestore> newCommentViewModelProvider;
+
+    late ProviderContainer container;
+
+    late PostIdFirestore postId;
+    late UserIdFirestore userId;
+
+    setUp(() async {
+      fakeFirestore = FakeFirebaseFirestore();
+      commentDataGenerator = CommentDataGenerator();
+      userId = testingUserFirestoreId;
+
+      container = ProviderContainer(
+        overrides: [
+          firestoreProvider.overrideWithValue(fakeFirestore),
+          uidProvider.overrideWithValue(userId),
+        ],
+      );
+
+      commentRepository = container.read(commentRepositoryProvider);
+
+      // Add a post to the database on which the comments will be added
+      final post = FirestorePostGenerator().generatePostAt(userPosition0);
+      await setPostFirestore(post, fakeFirestore);
+      postId = post.id;
+
+      newCommentViewModelProvider = newCommentStateProvider(postId);
+    });
+
+    test("Add a valid comment and reset correctly", () async {
+      final validContent = commentDataGenerator.createMockCommentData().content;
+
+      final newCommentViewModel =
+          container.read(newCommentViewModelProvider.notifier);
+
+      //  --- Check the state before adding the comment
+      final stateBeforeAdd = await newCommentViewModel.future;
+      expect(
+        stateBeforeAdd,
+        NewCommentState(contentError: null, posted: false),
+      );
+
+      // --- Add the comment
+      final timeBeforeAdd = Timestamp.now();
+      final addResult = await newCommentViewModel.tryAddComment(validContent);
+      final timeAfterAdd = Timestamp.now();
+
+      expect(addResult, isTrue);
+
+      // --- Get the comments
+      final comments = await commentRepository.getComments(postId);
+
+      expect(comments, hasLength(1));
+
+      final comment = comments.first;
+
+      expect(comment.data.content, validContent);
+      expect(comment.data.ownerId, userId);
+
+      // --- Check the publication time is between the timeBeforeAdd and timeAfterAdd
+      expect(
+        comment.data.publicationTime.microsecondsSinceEpoch,
+        greaterThanOrEqualTo(timeBeforeAdd.microsecondsSinceEpoch),
+      );
+      expect(
+        comment.data.publicationTime.microsecondsSinceEpoch,
+        lessThanOrEqualTo(timeAfterAdd.microsecondsSinceEpoch),
+      );
+
+      // --- Check the state after adding the comment
+      final stateAfterAdd = await newCommentViewModel.future;
+      expect(
+        stateAfterAdd,
+        NewCommentState(contentError: null, posted: true),
+      );
+
+      // --- Reset the state
+      await newCommentViewModel.reset();
+
+      // --- Check the state after resetting
+      final stateAfterReset = await newCommentViewModel.future;
+      expect(
+        stateAfterReset,
+        NewCommentState(contentError: null, posted: false),
+      );
+    });
+
+    test("Add an empty comment exposes error message", () async {
+      const invalidContent = "";
+
+      final newCommentViewModel =
+          container.read(newCommentViewModelProvider.notifier);
+
+      //  --- Check the state before adding the comment
+      final stateBeforeAdd = await newCommentViewModel.future;
+      expect(
+        stateBeforeAdd,
+        NewCommentState(contentError: null, posted: false),
+      );
+
+      // --- Add the comment
+      final addResult = await newCommentViewModel.tryAddComment(invalidContent);
+
+      expect(addResult, isFalse);
+
+      // --- Check the state after adding the comment
+      final stateAfterAdd = await newCommentViewModel.future;
+      expect(
+        stateAfterAdd,
+        NewCommentState(
+          contentError: NewCommentViewModel.contentEmptyError,
+          posted: false,
+        ),
+      );
+    });
+
+    test("Add a comment without being logged in expose error async state",
+        () async {
+      final validContent = commentDataGenerator.createMockCommentData().content;
+
+      final newCommentViewModel =
+          container.read(newCommentViewModelProvider.notifier);
+
+      container.updateOverrides([
+        firestoreProvider.overrideWithValue(fakeFirestore),
+        uidProvider.overrideWithValue(null),
+      ]);
+
+      final addResult = await newCommentViewModel.tryAddComment(validContent);
+      expect(addResult, isFalse);
+
+      expect(
+        () async => await newCommentViewModel.future,
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}

--- a/test/views/pages/post/post_page_test.dart
+++ b/test/views/pages/post/post_page_test.dart
@@ -1,0 +1,80 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:mockito/mockito.dart";
+import "package:proxima/models/database/comment/comment_data.dart";
+import "package:proxima/models/database/comment/comment_id_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/views/pages/post/post_page_widget/bottom_bar_add_comment.dart";
+
+import "../../../mocks/data/comment_data.dart";
+import "../../../mocks/data/firestore_comment.dart";
+import "../../../mocks/data/firestore_user.dart";
+import "../../../mocks/providers/provider_post_page.dart";
+import "../../../mocks/services/mock_comment_repository_service.dart";
+
+void main() {
+  late ProviderScope fakePostPage;
+
+  late UserIdFirestore userId;
+  late CommentIdFirestore commentId;
+
+  late MockCommentRepositoryService commentRepository;
+  late CommentDataGenerator commentDataGenerator;
+
+  group("Testing post page", () {
+    setUp(() {
+      commentRepository = MockCommentRepositoryService();
+      commentDataGenerator = CommentDataGenerator();
+      userId = testingUserFirestoreId;
+      commentId = CommentFirestoreGenerator().createMockComment().id;
+
+      fakePostPage = postPageProvider(commentRepository, userId);
+    });
+
+    testWidgets(
+      "Add a valid comment on a post",
+      (widgetTester) async {
+        await widgetTester.pumpWidget(fakePostPage);
+        await widgetTester.pumpAndSettle();
+
+        // Add a comment
+        final validContent =
+            commentDataGenerator.createMockCommentData().content;
+
+        final commentField =
+            find.byKey(BottomBarAddComment.addCommentTextFieldKey);
+        await widgetTester.enterText(commentField, validContent);
+        await widgetTester.pumpAndSettle();
+
+        when(commentRepository.addComment(any, any))
+            .thenAnswer((_) async => commentId);
+
+        final timeBeforeAdd = Timestamp.now();
+
+        final postButton = find.byKey(BottomBarAddComment.postCommentButtonKey);
+        await widgetTester.tap(postButton);
+        await widgetTester.pumpAndSettle();
+
+        final timeAfterAdd = Timestamp.now();
+
+        final CommentData capturedCommentData =
+            verify(commentRepository.addComment(any, captureAny))
+                .captured
+                .first;
+
+        expect(capturedCommentData.content, validContent);
+        expect(capturedCommentData.ownerId, userId);
+        expect(
+          capturedCommentData.publicationTime.microsecondsSinceEpoch,
+          greaterThanOrEqualTo(timeBeforeAdd.microsecondsSinceEpoch),
+        );
+        expect(
+          capturedCommentData.publicationTime.microsecondsSinceEpoch,
+          lessThanOrEqualTo(timeAfterAdd.microsecondsSinceEpoch),
+        );
+        expect(capturedCommentData.voteScore, 0);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Hello,
This PR aims to provide the view model to allow the user to comment under a post (issue #224).
With this PR, the user is able to comment under posts.

Concretely, this PR does the following:

**Model for state of adding a comment:**
This PR adds the class `NewCommentState` which represents the current state in the addition of a new comment. It exposes a possible error message and if the comment has been posted or not.

**Viewmodel for adding comment:**
This PR adds a view model for adding comment under a post. This is done through the class `NewCommentViewModel` inspired from the implementation of `NewPostViewModel`.
This `NewCommentViewModel` takes a parameter `PostIdFirestore` that represents the post under which the comment is added and it exposes the state `NewCommentState`.

One can a comment using the method `NewCommentViewModel.tryAddComment`. 
This one will validate the comment (check for emptyness). If the comment is invalid, an error message state is exposed.
Otherwise, the addition of the comment continues normally.

**Link the view model to the UI:**
The implementation of `BottomBarAddComment` has been modified to use the real `NewCommentViewModel`.
This required a little refactoring of the class to keep a good implementation.

**Tests for the view model:**
This PR adds some tests for both the viewmodel in itself as well as the view using the view model.

#### Live testing
You can live test these PR features as follows:
Open the app and click on a post.
Then you can try to add a comment under the post and you should see it appear immediately after clicking the add button.
You can also try to add an empty comment and you should see the text field displaying an error.

You should get the following behavior when adding valid comment: 
<img src="https://github.com/ProximaEPFL/proxima/assets/79637838/3bc7e416-de16-4354-b73a-09021f4a0f42" width=260>


#### Acceptance criteria:
- [ ] The user is able to add a comment on a post
- [ ] When the user adds a comment, a refresh happens such that the user directly sees its comments under the post
- [ ] The user cannot post a comment that is empty
- [ ] If the user tries to post a empty comment, the input field displays an error telling the user that he cannot post a empty comment


**Important note:** Waiting for #225 to be merged to change the base branch to main and merge.


Thank you for reviewing this PR and I look forward to your feedback :+1: 

