### PR TITLE
Test human readable time and distances values in UI

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   fake_cloud_firestore: ^2.4.8
   geoflutterfire_plus: ^0.0.20
   geolocator: ^11.0.0
-  mockito: ^5.4.4
   google_fonts: ^6.2.1
   google_maps_flutter: ^2.6.1
   flutter_svg: ^2.0.10+1
@@ -40,6 +39,7 @@ dev_dependencies:
   flutter_lints: ^3.0.0
   riverpod_lint: ^2.3.9
   test: ^1.24.9
+  mockito: ^5.4.4
 
 flutter:
   uses-material-design: true

--- a/test/mocks/data/post_overview.dart
+++ b/test/mocks/data/post_overview.dart
@@ -37,3 +37,15 @@ final List<PostOverview> testPosts = [
     distance: 20,
   ),
 ];
+
+// Custom post for testing specific date and distances
+final timeDistancePost = PostOverview(
+  postId: const PostIdFirestore(value: "post_1"),
+  title: "title",
+  description: "description",
+  voteScore: 1,
+  commentNumber: 5,
+  ownerDisplayName: "owner",
+  publicationDate: DateTime.utc(1999),
+  distance: 100,
+);

--- a/test/mocks/overrides/override_human_time.dart
+++ b/test/mocks/overrides/override_human_time.dart
@@ -1,0 +1,9 @@
+import "package:proxima/services/human_time_service.dart";
+
+import "../providers/provider_human_time_service.dart";
+
+final humanTimeServiceOverride = [
+  humanTimeServiceProvider.overrideWith(
+    (ref) => ref.watch(constantHumanTimeServiceProvider),
+  ),
+];

--- a/test/mocks/providers/provider_human_time_service.dart
+++ b/test/mocks/providers/provider_human_time_service.dart
@@ -1,0 +1,5 @@
+import "package:proxima/services/human_time_service.dart";
+
+CurrentDateTimeCallback constantTimeCallback() {
+  return () => DateTime.utc(2000);
+}

--- a/test/mocks/providers/provider_human_time_service.dart
+++ b/test/mocks/providers/provider_human_time_service.dart
@@ -1,5 +1,19 @@
+import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/services/human_time_service.dart";
 
 CurrentDateTimeCallback constantTimeCallback() {
   return () => DateTime.utc(2000);
 }
+
+final constantDateTimeCallbackProvider =
+    Provider<CurrentDateTimeCallback>((ref) {
+  return constantTimeCallback();
+});
+
+final constantHumanTimeServiceProvider = Provider<HumanTimeService>((ref) {
+  final currentDateTimeCallback = ref.watch(constantDateTimeCallbackProvider);
+
+  return HumanTimeService(
+    currentDateTimeCallback: currentDateTimeCallback,
+  );
+});

--- a/test/mocks/providers/provider_human_time_service.dart
+++ b/test/mocks/providers/provider_human_time_service.dart
@@ -1,8 +1,10 @@
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/services/human_time_service.dart";
 
+final constantTestingTime = DateTime.utc(2000);
+
 CurrentDateTimeCallback constantTimeCallback() {
-  return () => DateTime.utc(2000);
+  return () => constantTestingTime;
 }
 
 final constantDateTimeCallbackProvider =

--- a/test/mocks/providers/provider_post_page.dart
+++ b/test/mocks/providers/provider_post_page.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/models/ui/post_overview.dart";
 import "package:proxima/services/database/comment_repository_service.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
 import "package:proxima/views/navigation/routes.dart";
@@ -42,4 +43,20 @@ ProviderScope postPageProvider(
     ],
     child: postPage,
   );
+}
+
+ProviderScope customPostOverviewPage(PostOverview post) {
+  final customPostApp = MaterialApp(
+    onGenerateRoute: generateRoute,
+    home: PostPage(
+      postOverview: post,
+    ),
+  );
+
+  final app = ProviderScope(
+    overrides: mockEmptyCommentViewModelOverride,
+    child: customPostApp,
+  );
+
+  return app;
 }

--- a/test/mocks/providers/provider_post_page.dart
+++ b/test/mocks/providers/provider_post_page.dart
@@ -62,7 +62,7 @@ ProviderScope customPostOverviewPage(PostOverview post) {
     ),
   );
 
-  final app = ProviderScope(
+  return ProviderScope(
     overrides: [
       ...mockDynamicUserAvatarViewModelTestLoginUserOverride,
       ...mockEmptyCommentViewModelOverride,
@@ -70,6 +70,4 @@ ProviderScope customPostOverviewPage(PostOverview post) {
     ],
     child: customPostApp,
   );
-
-  return app;
 }

--- a/test/mocks/providers/provider_post_page.dart
+++ b/test/mocks/providers/provider_post_page.dart
@@ -11,6 +11,7 @@ import "../data/post_overview.dart";
 import "../overrides/override_comment_view_model.dart";
 import "../overrides/override_firestore.dart";
 import "../services/mock_comment_repository_service.dart";
+import "provider_human_time_service.dart";
 
 // Create a post page with the first post from the testPosts list
 final postPage = MaterialApp(
@@ -54,7 +55,10 @@ ProviderScope customPostOverviewPage(PostOverview post) {
   );
 
   final app = ProviderScope(
-    overrides: mockEmptyCommentViewModelOverride,
+    overrides: [
+      ...mockEmptyCommentViewModelOverride,
+      constantHumanTimeServiceProvider,
+    ],
     child: customPostApp,
   );
 

--- a/test/mocks/providers/provider_post_page.dart
+++ b/test/mocks/providers/provider_post_page.dart
@@ -13,7 +13,6 @@ import "../overrides/override_dynamic_user_avatar_view_model.dart";
 import "../overrides/override_firestore.dart";
 import "../overrides/override_human_time.dart";
 import "../services/mock_comment_repository_service.dart";
-import "provider_human_time_service.dart";
 
 // Create a post page with the first post from the testPosts list
 final postPage = MaterialApp(
@@ -65,6 +64,7 @@ ProviderScope customPostOverviewPage(PostOverview post) {
 
   final app = ProviderScope(
     overrides: [
+      ...mockDynamicUserAvatarViewModelTestLoginUserOverride,
       ...mockEmptyCommentViewModelOverride,
       ...humanTimeServiceOverride,
     ],

--- a/test/mocks/providers/provider_post_page.dart
+++ b/test/mocks/providers/provider_post_page.dart
@@ -10,6 +10,7 @@ import "package:proxima/views/pages/post/post_page.dart";
 import "../data/post_overview.dart";
 import "../overrides/override_comment_view_model.dart";
 import "../overrides/override_firestore.dart";
+import "../overrides/override_human_time.dart";
 import "../services/mock_comment_repository_service.dart";
 import "provider_human_time_service.dart";
 
@@ -57,7 +58,7 @@ ProviderScope customPostOverviewPage(PostOverview post) {
   final app = ProviderScope(
     overrides: [
       ...mockEmptyCommentViewModelOverride,
-      constantHumanTimeServiceProvider,
+      ...humanTimeServiceOverride,
     ],
     child: customPostApp,
   );

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -57,7 +57,7 @@ void main() {
 
     test("Check special case 'now' relative time", () {
       // Setup actual relative values for 'now' case
-      final nowTime = constantTestingTime.add(const Duration(seconds: 1));
+      final nowTime = constantTestingTime.subtract(const Duration(seconds: 1));
 
       const expectedNowRelativeTime = "now";
 

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -13,16 +13,38 @@ void main() {
       );
     });
 
-    test("Check correct absolute time 1", () {
+    test("Check correct simple absolute time", () {
       final time1 = DateTime.utc(2002);
-      const expectedHumanText = "Tuesday, January 1, 2002 00:00";
+      const expectedSimpleHumanText = "Tuesday, January 1, 2002 00:00";
 
-      final actualHumanText = humanTimeService.textTimeAbsolute(time1);
-      expect(
-        actualHumanText,
-        expectedHumanText,
+      final actualSimpleHumanText = humanTimeService.textTimeAbsolute(
+        time1,
       );
-      // humanTimeService.
+
+      expect(
+        actualSimpleHumanText,
+        expectedSimpleHumanText,
+      );
+    });
+
+    test("Check correct complex absolute time", () {
+      final time2 = DateTime.utc(
+        2023,
+        11,
+        21,
+        1,
+      );
+
+      const expectedComplexHumanText = "Tuesday, November 21, 2023 01:00";
+
+      final actualComplexHumanText = humanTimeService.textTimeAbsolute(
+        time2,
+      );
+
+      expect(
+        actualComplexHumanText,
+        expectedComplexHumanText,
+      );
     });
   });
 }

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -8,10 +8,21 @@ void main() {
     late HumanTimeService humanTimeService;
 
     setUp(() {
-      humanTimeService =
-          HumanTimeService(currentDateTimeCallback: constantTimeCallback());
+      humanTimeService = HumanTimeService(
+        currentDateTimeCallback: constantTimeCallback(),
+      );
     });
 
-    test("Check correct absolute time 1", () {});
+    test("Check correct absolute time 1", () {
+      final time1 = DateTime.utc(2002);
+      const expectedHumanText = "Tuesday, January 1, 2002 00:00";
+
+      final actualHumanText = humanTimeService.textTimeAbsolute(time1);
+      expect(
+        actualHumanText,
+        expectedHumanText,
+      );
+      // humanTimeService.
+    });
   });
 }

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -50,11 +50,50 @@ void main() {
     test("Check special case 'now' relative time", () {
       final nowTime = constantTestingTime.add(const Duration(seconds: 1));
 
+      const expectedNowRelativeTime = "now";
+
       final actualNowTimeHumanText = humanTimeService.textTimeSince(
         nowTime,
       );
 
-      expect(actualNowTimeHumanText, "now");
+      expect(
+        actualNowTimeHumanText,
+        expectedNowRelativeTime,
+      );
+    });
+
+    test("Check 10 minutes relative time", () {
+      final relative10Minutes = constantTestingTime.subtract(
+        const Duration(minutes: 10),
+      );
+
+      const expectedRelative10Minutes = "10m ago";
+
+      final actualMinuteTimeHumanText = humanTimeService.textTimeSince(
+        relative10Minutes,
+      );
+
+      expect(
+        actualMinuteTimeHumanText,
+        expectedRelative10Minutes,
+      );
+    });
+
+    test("Check 4 days relative time", () {
+      final relative4Days = constantTestingTime.subtract(
+        const Duration(days: 4),
+      );
+
+      const expectedRelative4Days = "4d ago";
+
+      final actualDaysTimeHumanText = humanTimeService.textTimeSince(
+        relative4Days,
+      );
+
+      expect(
+        actualDaysTimeHumanText,
+        expectedRelative4Days,
+      );
     });
   });
 }

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -57,13 +57,15 @@ void main() {
 
     test("Check special case 'now' relative time", () {
       // Setup actual relative values for 'now' case
-      final nowTime = constantTestingTime.subtract(const Duration(seconds: 1));
+      final closeToNowTime = constantTestingTime.subtract(
+        const Duration(seconds: 1),
+      );
 
       const expectedNowRelativeTime = "now";
 
       // Use the service to get relative human time
       final actualNowTimeHumanText = humanTimeService.textTimeSince(
-        nowTime,
+        closeToNowTime,
       );
 
       // Check that the time value is correctly 'now'

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -25,7 +25,7 @@ void main() {
         time1,
       );
 
-      // Check that the absolut time value is correct
+      // Check that the absolute time value is correct
       expect(
         actualSimpleHumanText,
         expectedSimpleHumanText,
@@ -48,7 +48,7 @@ void main() {
         time2,
       );
 
-      // Check that the specific absolut time value is correct
+      // Check that the specific absolute time value is correct
       expect(
         actualComplexHumanText,
         expectedComplexHumanText,
@@ -76,7 +76,7 @@ void main() {
     });
 
     test("Check 10 minutes relative time", () {
-      // Setup specific time values for 10 min before contsant time
+      // Setup specific time values for 10 min before constant time
       final relative10Minutes = constantTestingTime.subtract(
         const Duration(minutes: 10),
       );
@@ -96,7 +96,7 @@ void main() {
     });
 
     test("Check 4 days relative time", () {
-      // Setup specific time values for 4 days before contsant time
+      // Setup specific time values for 4 days before constant time
       final relative4Days = constantTestingTime.subtract(
         const Duration(days: 4),
       );

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -46,5 +46,15 @@ void main() {
         expectedComplexHumanText,
       );
     });
+
+    test("Check special case 'now' relative time", () {
+      final nowTime = constantTestingTime.add(const Duration(seconds: 1));
+
+      final actualNowTimeHumanText = humanTimeService.textTimeSince(
+        nowTime,
+      );
+
+      expect(actualNowTimeHumanText, "now");
+    });
   });
 }

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -8,19 +8,24 @@ void main() {
     late HumanTimeService humanTimeService;
 
     setUp(() {
+      // Setup the `HumanTimeService` for constant time
       humanTimeService = HumanTimeService(
         currentDateTimeCallback: constantTimeCallback(),
       );
     });
 
     test("Check correct simple absolute time", () {
+      // Setup actual values for simple date
       final time1 = DateTime.utc(2002);
+
       const expectedSimpleHumanText = "Tuesday, January 1, 2002 00:00";
 
+      // Use the service to get human time
       final actualSimpleHumanText = humanTimeService.textTimeAbsolute(
         time1,
       );
 
+      // Check that the absolut time value is correct
       expect(
         actualSimpleHumanText,
         expectedSimpleHumanText,
@@ -28,6 +33,7 @@ void main() {
     });
 
     test("Check correct complex absolute time", () {
+      // Setup actual values for complex specific date
       final time2 = DateTime.utc(
         2023,
         11,
@@ -37,10 +43,12 @@ void main() {
 
       const expectedComplexHumanText = "Tuesday, November 21, 2023 01:00";
 
+      // Use the service to get human time
       final actualComplexHumanText = humanTimeService.textTimeAbsolute(
         time2,
       );
 
+      // Check that the specific absolut time value is correct
       expect(
         actualComplexHumanText,
         expectedComplexHumanText,
@@ -48,14 +56,17 @@ void main() {
     });
 
     test("Check special case 'now' relative time", () {
+      // Setup actual relative values for 'now' case
       final nowTime = constantTestingTime.add(const Duration(seconds: 1));
 
       const expectedNowRelativeTime = "now";
 
+      // Use the service to get relative human time
       final actualNowTimeHumanText = humanTimeService.textTimeSince(
         nowTime,
       );
 
+      // Check that the time value is correctly 'now'
       expect(
         actualNowTimeHumanText,
         expectedNowRelativeTime,
@@ -63,16 +74,19 @@ void main() {
     });
 
     test("Check 10 minutes relative time", () {
+      // Setup specific time values for 10 min before contsant time
       final relative10Minutes = constantTestingTime.subtract(
         const Duration(minutes: 10),
       );
 
       const expectedRelative10Minutes = "10m ago";
 
+      // Use the service to get relative human time
       final actualMinuteTimeHumanText = humanTimeService.textTimeSince(
         relative10Minutes,
       );
 
+      // Check that the time value is correct for 10 minutes
       expect(
         actualMinuteTimeHumanText,
         expectedRelative10Minutes,
@@ -80,16 +94,19 @@ void main() {
     });
 
     test("Check 4 days relative time", () {
+      // Setup specific time values for 4 days before contsant time
       final relative4Days = constantTestingTime.subtract(
         const Duration(days: 4),
       );
 
       const expectedRelative4Days = "4d ago";
 
+      // Use the service to get relative human time
       final actualDaysTimeHumanText = humanTimeService.textTimeSince(
         relative4Days,
       );
 
+      // Check that the time value is correct for 4 days
       expect(
         actualDaysTimeHumanText,
         expectedRelative4Days,

--- a/test/services/human_time_service_test.dart
+++ b/test/services/human_time_service_test.dart
@@ -1,0 +1,17 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:proxima/services/human_time_service.dart";
+
+import "../mocks/providers/provider_human_time_service.dart";
+
+void main() {
+  group("Human Time Service Unit tests", () {
+    late HumanTimeService humanTimeService;
+
+    setUp(() {
+      humanTimeService =
+          HumanTimeService(currentDateTimeCallback: constantTimeCallback());
+    });
+
+    test("Check correct absolute time 1", () {});
+  });
+}

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -1,10 +1,7 @@
+import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
-import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/ui/post_overview.dart";
-import "package:proxima/views/home_content/feed/post_card/post_card.dart";
-import "package:proxima/views/home_content/feed/post_card/post_header_widget.dart";
-import "package:proxima/views/pages/post/post_page.dart";
 import "package:proxima/views/pages/post/post_page_widget/complete_post_widget.dart";
 
 import "../../../mocks/data/post_overview.dart";
@@ -12,7 +9,7 @@ import "../../../mocks/providers/provider_post_page.dart";
 import "../../../mocks/services/setup_firebase_mocks.dart";
 
 void main() {
-  late ProviderScope emptyPostPageWidget;
+  // Custom post for testing specific date and distances
   final customPost = PostOverview(
     postId: const PostIdFirestore(value: "post_1"),
     title: "title",
@@ -26,19 +23,17 @@ void main() {
 
   setUp(() async {
     setupFirebaseAuthMocks();
-
-    emptyPostPageWidget = emptyPostPageProvider;
   });
 
   group("Post Distances and Timing values", () {
     testWidgets("Check correct distance on basic post", (tester) async {
-      await tester.pumpWidget(emptyPostPageWidget);
+      await tester.pumpWidget(emptyPostPageProvider);
       await tester.pumpAndSettle();
 
       final post = testPosts.first;
-      final actualDistanceText = "${post.distance}m away";
+      final expectedDistanceText = "${post.distance}m away";
 
-      final distanceDisplay = find.text(actualDistanceText);
+      final distanceDisplay = find.text(expectedDistanceText);
 
       expect(distanceDisplay, findsOneWidget);
     });
@@ -47,22 +42,31 @@ void main() {
       await tester.pumpWidget(customPostOverviewPage(customPost));
       await tester.pumpAndSettle();
 
-      final actualDistanceText = "${customPost.distance}m away";
+      final expectedDistanceText = "${customPost.distance}m away";
 
-      final distanceDisplay = find.text(actualDistanceText);
+      final appBar = find.byType(AppBar);
+      expect(appBar, findsOneWidget);
 
-      expect(distanceDisplay, findsOneWidget);
+      final actualDistanceDisplayed = find.descendant(
+        of: appBar,
+        matching: find.text(expectedDistanceText),
+      );
+
+      expect(actualDistanceDisplayed, findsOneWidget);
     });
 
-    testWidgets("Check correct timing on basic post", (tester) async {
+    testWidgets("Check correct timing on basic post, special 'now' case",
+        (tester) async {
       await tester.pumpWidget(customPostOverviewPage(testPosts.first));
       await tester.pumpAndSettle();
 
       const expectedTimeValue = "now";
 
-      final publicationDateText = find.byKey(CompletePostWidget.postUserBarKey);
+      final postUserBar = find.byKey(CompletePostWidget.postUserBarKey);
+      expect(postUserBar, findsOneWidget);
+
       final actualTimeDisplayed = find.descendant(
-        of: publicationDateText,
+        of: postUserBar,
         matching: find.text(expectedTimeValue),
       );
 

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -2,7 +2,6 @@ import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/ui/post_overview.dart";
-import "package:proxima/views/home_content/feed/post_card/post_header_widget.dart";
 import "package:proxima/views/pages/post/post_page_widget/complete_post_widget.dart";
 
 import "../../../mocks/data/post_overview.dart";
@@ -34,8 +33,10 @@ void main() {
       final post = testPosts.first;
       final expectedDistanceText = "${post.distance}m away";
 
+      // Find post distance value with expected human readable distance
       final distanceDisplay = find.text(expectedDistanceText);
 
+      // Check that the distance is displayed with correct value
       expect(distanceDisplay, findsOneWidget);
     });
 
@@ -45,14 +46,18 @@ void main() {
 
       final expectedDistanceText = "${customPost.distance}m away";
 
+      // Find the container for the distance
       final appBar = find.byType(AppBar);
+      // Check that the container is correctly displayed
       expect(appBar, findsOneWidget);
 
+      // Find the child widget of the appBar (containing the distance)
       final actualDistanceDisplayed = find.descendant(
         of: appBar,
         matching: find.text(expectedDistanceText),
       );
 
+      // Check that the distance is correctly displayed and with the right value
       expect(actualDistanceDisplayed, findsOneWidget);
     });
 
@@ -63,14 +68,17 @@ void main() {
 
       const expectedTimeValue = "now";
 
+      // Find the parent of the timing text
       final postUserBar = find.byKey(CompletePostWidget.postUserBarKey);
       expect(postUserBar, findsOneWidget);
 
+      // Find if the parent contains a child with the expected timing text
       final actualTimeDisplayed = find.descendant(
         of: postUserBar,
         matching: find.text(expectedTimeValue),
       );
 
+      // Check the special case 'now' is correctly handled in UI
       expect(actualTimeDisplayed, findsOneWidget);
     });
 
@@ -80,14 +88,17 @@ void main() {
 
       const expectedTimeValue = "~1y ago";
 
+      // Find the parent of the timing text
       final postUserBar = find.byKey(CompletePostWidget.postUserBarKey);
       expect(postUserBar, findsOneWidget);
 
+      // Find if the parent contains a child with the expected timing text
       final actualTimeDisplayed = find.descendant(
         of: postUserBar,
         matching: find.text(expectedTimeValue),
       );
 
+      // Check the timing value is correct
       expect(actualTimeDisplayed, findsOneWidget);
     });
   });

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -1,8 +1,6 @@
 import "package:firebase_core/firebase_core.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
-import "package:proxima/models/database/post/post_id_firestore.dart";
-import "package:proxima/models/ui/post_overview.dart";
 import "package:proxima/views/pages/post/post_page_widget/complete_post_widget.dart";
 
 import "../../../mocks/data/post_overview.dart";
@@ -10,18 +8,6 @@ import "../../../mocks/providers/provider_post_page.dart";
 import "../../../mocks/services/setup_firebase_mocks.dart";
 
 void main() {
-  // Custom post for testing specific date and distances
-  final customPost = PostOverview(
-    postId: const PostIdFirestore(value: "post_1"),
-    title: "title",
-    description: "description",
-    voteScore: 1,
-    commentNumber: 5,
-    ownerDisplayName: "owner",
-    publicationDate: DateTime.utc(1999),
-    distance: 100,
-  );
-
   setUp(() async {
     setupFirebaseAuthMocks();
     await Firebase.initializeApp();
@@ -43,10 +29,10 @@ void main() {
     });
 
     testWidgets("Check correct distance on custom post", (tester) async {
-      await tester.pumpWidget(customPostOverviewPage(customPost));
+      await tester.pumpWidget(customPostOverviewPage(timeDistancePost));
       await tester.pumpAndSettle();
 
-      final expectedDistanceText = "${customPost.distance}m away";
+      final expectedDistanceText = "${timeDistancePost.distance}m away";
 
       // Find the container for the distance
       final appBar = find.byType(AppBar);
@@ -85,7 +71,7 @@ void main() {
     });
 
     testWidgets("Check correct timing on custom post", (tester) async {
-      await tester.pumpWidget(customPostOverviewPage(customPost));
+      await tester.pumpWidget(customPostOverviewPage(timeDistancePost));
       await tester.pumpAndSettle();
 
       const expectedTimeValue = "~1y ago";

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/ui/post_overview.dart";
+import "package:proxima/views/home_content/feed/post_card/post_header_widget.dart";
 import "package:proxima/views/pages/post/post_page_widget/complete_post_widget.dart";
 
 import "../../../mocks/data/post_overview.dart";
@@ -61,6 +62,23 @@ void main() {
       await tester.pumpAndSettle();
 
       const expectedTimeValue = "now";
+
+      final postUserBar = find.byKey(CompletePostWidget.postUserBarKey);
+      expect(postUserBar, findsOneWidget);
+
+      final actualTimeDisplayed = find.descendant(
+        of: postUserBar,
+        matching: find.text(expectedTimeValue),
+      );
+
+      expect(actualTimeDisplayed, findsOneWidget);
+    });
+
+    testWidgets("Check correct timing on custom post", (tester) async {
+      await tester.pumpWidget(customPostOverviewPage(customPost));
+      await tester.pumpAndSettle();
+
+      const expectedTimeValue = "~1y ago";
 
       final postUserBar = find.byKey(CompletePostWidget.postUserBarKey);
       expect(postUserBar, findsOneWidget);

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -1,5 +1,7 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
+import "package:proxima/models/ui/post_overview.dart";
 
 import "../../../mocks/data/post_overview.dart";
 import "../../../mocks/providers/provider_post_page.dart";
@@ -7,6 +9,16 @@ import "../../../mocks/services/setup_firebase_mocks.dart";
 
 void main() {
   late ProviderScope emptyPostPageWidget;
+  final customPost = PostOverview(
+    postId: const PostIdFirestore(value: "post_1"),
+    title: "title",
+    description: "description",
+    voteScore: 1,
+    commentNumber: 5,
+    ownerDisplayName: "owner",
+    publicationDate: DateTime.utc(1999),
+    distance: 100,
+  );
 
   setUp(() async {
     setupFirebaseAuthMocks();
@@ -21,6 +33,17 @@ void main() {
 
       final post = testPosts.first;
       final actualDistanceText = "${post.distance}m away";
+
+      final distanceDisplay = find.text(actualDistanceText);
+
+      expect(distanceDisplay, findsOneWidget);
+    });
+
+    testWidgets("Check correct distance on custom post", (tester) async {
+      await tester.pumpWidget(customPostOverviewPage(customPost));
+      await tester.pumpAndSettle();
+
+      final actualDistanceText = "${customPost.distance}m away";
 
       final distanceDisplay = find.text(actualDistanceText);
 

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -2,6 +2,10 @@ import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/ui/post_overview.dart";
+import "package:proxima/views/home_content/feed/post_card/post_card.dart";
+import "package:proxima/views/home_content/feed/post_card/post_header_widget.dart";
+import "package:proxima/views/pages/post/post_page.dart";
+import "package:proxima/views/pages/post/post_page_widget/complete_post_widget.dart";
 
 import "../../../mocks/data/post_overview.dart";
 import "../../../mocks/providers/provider_post_page.dart";
@@ -26,7 +30,7 @@ void main() {
     emptyPostPageWidget = emptyPostPageProvider;
   });
 
-  group("Distances and Timing values", () {
+  group("Post Distances and Timing values", () {
     testWidgets("Check correct distance on basic post", (tester) async {
       await tester.pumpWidget(emptyPostPageWidget);
       await tester.pumpAndSettle();
@@ -48,6 +52,21 @@ void main() {
       final distanceDisplay = find.text(actualDistanceText);
 
       expect(distanceDisplay, findsOneWidget);
+    });
+
+    testWidgets("Check correct timing on basic post", (tester) async {
+      await tester.pumpWidget(customPostOverviewPage(testPosts.first));
+      await tester.pumpAndSettle();
+
+      const expectedTimeValue = "now";
+
+      final publicationDateText = find.byKey(CompletePostWidget.postUserBarKey);
+      final actualTimeDisplayed = find.descendant(
+        of: publicationDateText,
+        matching: find.text(expectedTimeValue),
+      );
+
+      expect(actualTimeDisplayed, findsOneWidget);
     });
   });
 }

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -1,3 +1,4 @@
+import "package:firebase_core/firebase_core.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
@@ -23,6 +24,7 @@ void main() {
 
   setUp(() async {
     setupFirebaseAuthMocks();
+    await Firebase.initializeApp();
   });
 
   group("Post Distances and Timing values", () {

--- a/test/views/pages/post/post_page_values_test.dart
+++ b/test/views/pages/post/post_page_values_test.dart
@@ -1,0 +1,30 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+
+import "../../../mocks/data/post_overview.dart";
+import "../../../mocks/providers/provider_post_page.dart";
+import "../../../mocks/services/setup_firebase_mocks.dart";
+
+void main() {
+  late ProviderScope emptyPostPageWidget;
+
+  setUp(() async {
+    setupFirebaseAuthMocks();
+
+    emptyPostPageWidget = emptyPostPageProvider;
+  });
+
+  group("Distances and Timing values", () {
+    testWidgets("Check correct distance on basic post", (tester) async {
+      await tester.pumpWidget(emptyPostPageWidget);
+      await tester.pumpAndSettle();
+
+      final post = testPosts.first;
+      final actualDistanceText = "${post.distance}m away";
+
+      final distanceDisplay = find.text(actualDistanceText);
+
+      expect(distanceDisplay, findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #209

### Timing and distances values testing

This PR's goal is to test two new parts of the application:

- The distances values between posts displayed as human readable format.
- The new human readable values provided by the new service added in PR #234.

The testing relies heavily on Dependency Injection to make sure relative times are consistent across different testing environments and time zones.

Don't hesitate to ask question below if anything in the code is not clear :)

**Note**: first relevant commit is 1a62d3f.

#### Code

The testing is composed of two types of tests:

- Unit tests for the human time service that are done in `test/services/human_time_service_test.dart`
- Component testing for the human time service and the distances in the UI testing files.

I also added the providers override and helpers for testing the human time service:

- With constant time callback functions definitions + the two testing providers `constantDateTimeCallbackProvider` and `constantHumanTimeServiceProvider` that go with it: `test/mocks/providers/provider_human_time_service.dart`
- The simple `humanTimeServiceOverride` overriding the corresponding provider: `test/mocks/overrides/override_human_time.dart`

I think I used our new testing code correctly (after refactor in #122), if I did something that goes against this refactor's philosophy please let me know :)

#### Acceptance criteria (from #209)

- [x] Test the value of distance of Challenges and posts
- [x] Test the value of the date of posts and comments

**Note**: this PR also moves the `mockito` package to dev dependencies.