### PR TITLE
upvote repositories refactor

### DIFF
--- a/lib/services/database/comment_upvote_repository_service.dart
+++ b/lib/services/database/comment_upvote_repository_service.dart
@@ -1,8 +1,5 @@
 import "package:hooks_riverpod/hooks_riverpod.dart";
-import "package:proxima/models/database/comment/comment_data.dart";
-import "package:proxima/models/database/comment/comment_firestore.dart";
 import "package:proxima/models/database/comment/comment_id_firestore.dart";
-import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/services/database/firestore_service.dart";
 import "package:proxima/services/database/upvote_repository_service.dart";
@@ -10,15 +7,8 @@ import "package:proxima/services/database/upvote_repository_service.dart";
 final commentUpvoteRepositoryProvider = Provider.family<
     UpvoteRepositoryService<CommentIdFirestore>,
     PostIdFirestore>((ref, postId) {
-  final firestore = ref.read(firestoreProvider);
-  final parentCollection = firestore
-      .collection(PostFirestore.collectionName)
-      .doc(postId.value)
-      .collection(CommentFirestore.subCollectionName);
-
-  return UpvoteRepositoryService(
-    firestore: firestore,
-    parentCollection: parentCollection,
-    voteScoreField: CommentData.voteScoreField,
+  return UpvoteRepositoryService.commentUpvoteRepository(
+    ref.watch(firestoreProvider),
+    postId,
   );
 });

--- a/lib/services/database/post_upvote_repository_service.dart
+++ b/lib/services/database/post_upvote_repository_service.dart
@@ -1,16 +1,11 @@
 import "package:hooks_riverpod/hooks_riverpod.dart";
-import "package:proxima/models/database/post/post_data.dart";
-import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/services/database/firestore_service.dart";
 import "package:proxima/services/database/upvote_repository_service.dart";
 
 final postUpvoteRepositoryProvider =
     Provider<UpvoteRepositoryService<PostIdFirestore>>((ref) {
-  final firestore = ref.watch(firestoreProvider);
-  return UpvoteRepositoryService(
-    firestore: firestore,
-    parentCollection: firestore.collection(PostFirestore.collectionName),
-    voteScoreField: PostData.voteScoreField,
+  return UpvoteRepositoryService.postUpvoteRepository(
+    ref.watch(firestoreProvider),
   );
 });

--- a/lib/services/database/upvote_repository_service.dart
+++ b/lib/services/database/upvote_repository_service.dart
@@ -25,6 +25,8 @@ class UpvoteRepositoryService<ParentIdFirestore extends IdFirestore> {
         _parentCollection = parentCollection,
         _voteScoreField = voteScoreField;
 
+  /// Returns an instance of [UpvoteRepositoryService] for up-voting posts that
+  /// are stored in the [firestore] database.
   static UpvoteRepositoryService<PostIdFirestore> postUpvoteRepository(
     FirebaseFirestore firestore,
   ) {
@@ -35,6 +37,9 @@ class UpvoteRepositoryService<ParentIdFirestore extends IdFirestore> {
     );
   }
 
+  /// Returns an instance of [UpvoteRepositoryService] for up-voting comments
+  /// relating to the post with id [postId]. Everything is stored in the
+  /// [firestore] database.
   static UpvoteRepositoryService<CommentIdFirestore> commentUpvoteRepository(
     FirebaseFirestore firestore,
     PostIdFirestore postId,

--- a/lib/services/database/upvote_repository_service.dart
+++ b/lib/services/database/upvote_repository_service.dart
@@ -1,5 +1,11 @@
 import "package:cloud_firestore/cloud_firestore.dart";
+import "package:proxima/models/database/comment/comment_data.dart";
+import "package:proxima/models/database/comment/comment_firestore.dart";
+import "package:proxima/models/database/comment/comment_id_firestore.dart";
 import "package:proxima/models/database/firestore/id_firestore.dart";
+import "package:proxima/models/database/post/post_data.dart";
+import "package:proxima/models/database/post/post_firestore.dart";
+import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/database/user/user_id_firestore.dart";
 import "package:proxima/models/database/vote/upvote_state.dart";
 import "package:proxima/models/database/vote/vote_firestore.dart";
@@ -11,13 +17,38 @@ class UpvoteRepositoryService<ParentIdFirestore extends IdFirestore> {
   final CollectionReference<Map<String, dynamic>> _parentCollection;
   final String _voteScoreField;
 
-  UpvoteRepositoryService({
+  UpvoteRepositoryService._({
     required FirebaseFirestore firestore,
     required CollectionReference<Map<String, dynamic>> parentCollection,
     required voteScoreField,
   })  : _firestore = firestore,
         _parentCollection = parentCollection,
         _voteScoreField = voteScoreField;
+
+  static UpvoteRepositoryService<PostIdFirestore> postUpvoteRepository(
+    FirebaseFirestore firestore,
+  ) {
+    return UpvoteRepositoryService._(
+      firestore: firestore,
+      parentCollection: firestore.collection(PostFirestore.collectionName),
+      voteScoreField: PostData.voteScoreField,
+    );
+  }
+
+  static UpvoteRepositoryService<CommentIdFirestore> commentUpvoteRepository(
+    FirebaseFirestore firestore,
+    PostIdFirestore postId,
+  ) {
+    final parentCollection = firestore
+        .collection(PostFirestore.collectionName)
+        .doc(postId.value)
+        .collection(CommentFirestore.subCollectionName);
+    return UpvoteRepositoryService._(
+      firestore: firestore,
+      parentCollection: parentCollection,
+      voteScoreField: CommentData.voteScoreField,
+    );
+  }
 
   /// Returns the document reference of the parent with id [parentId]
   DocumentReference<Map<String, dynamic>> _parentDocument(


### PR DESCRIPTION
This PR is a small refactor to make it easier to use post and comment upvote repositories.

It makes the constructor that uses database information private and exposes intuitive constructors for a post and comment upvote repo.