### PR TITLE
Challenges option on the map

### DIFF
--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -6,6 +6,7 @@ import "package:proxima/services/database/challenge_repository_service.dart";
 import "package:proxima/services/database/post_repository_service.dart";
 import "package:proxima/services/sensors/geolocation_service.dart";
 import "package:proxima/viewmodels/login_view_model.dart";
+import "package:proxima/viewmodels/map/map_pin_view_model.dart";
 
 /// This viewmodel is used to fetch the list of challenges that are displayed in
 /// the challenge feed. It fetches the challenges from the database and sorts
@@ -91,6 +92,9 @@ class ChallengeViewModel extends AsyncNotifier<List<ChallengeDetails>> {
       // if we do we might have a weird double loading, but probably not
       // can change if we have a problem
       refresh();
+
+      // Refresh the map pins after challenge completion
+      ref.read(mapPinViewModelProvider.notifier).refresh();
     }
 
     return pointsAwarded;

--- a/lib/viewmodels/map/map_pin_view_model.dart
+++ b/lib/viewmodels/map/map_pin_view_model.dart
@@ -1,3 +1,4 @@
+import "package:collection/collection.dart";
 import "package:google_maps_flutter/google_maps_flutter.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/post/post_firestore.dart";
@@ -54,7 +55,7 @@ class MapPinViewModel extends AsyncNotifier<List<MapPinDetails>> {
     return userPosts.map(_toMapPinDetails).toList();
   }
 
-  /// Get user challenges
+  /// Get user active challenges
   Future<List<MapPinDetails>> _getUserChallenges() async {
     final postRepository = ref.watch(postRepositoryServiceProvider);
     final challengeRepostory = ref.watch(challengeRepositoryServiceProvider);
@@ -71,8 +72,11 @@ class MapPinViewModel extends AsyncNotifier<List<MapPinDetails>> {
       userId,
       position,
     );
+    final activeChallenges = userChallenges.whereNot(
+      (challenge) => challenge.data.isCompleted,
+    );
     final posts = await Future.wait(
-      userChallenges.map(
+      activeChallenges.map(
         (challenge) => postRepository.getPost(challenge.postId),
       ),
     );

--- a/lib/viewmodels/map/map_pin_view_model.dart
+++ b/lib/viewmodels/map/map_pin_view_model.dart
@@ -72,11 +72,8 @@ class MapPinViewModel extends AutoDisposeAsyncNotifier<List<MapPinDetails>> {
     final userId = ref.watch(validLoggedInUserIdProvider);
     // Only doing a read here, to decrease the number of database reads
     // (we don't want to re-read the challenges when the position changes).
-    final position = await ref.read(livePositionStreamProvider.future);
-
-    if (position == null) {
-      return List.empty();
-    }
+    final position =
+        await ref.read(geolocationServiceProvider).getCurrentPosition();
 
     final userChallenges = await challengeRepostory.getChallenges(
       userId,

--- a/test/views/pages/map/dynamic_map_test.dart
+++ b/test/views/pages/map/dynamic_map_test.dart
@@ -11,6 +11,7 @@ import "package:proxima/views/components/options/map/map_selection_option_chips.
 import "package:proxima/views/components/options/map/map_selection_options.dart";
 import "package:proxima/views/pages/home/content/map/map_screen.dart";
 
+import "../../../mocks/data/firestore_challenge.dart";
 import "../../../mocks/data/firestore_post.dart";
 import "../../../mocks/data/firestore_user.dart";
 import "../../../mocks/data/geopoint.dart";
@@ -73,6 +74,7 @@ void main() {
   group("Option selection", () {
     late List<PostFirestore> nearbyPosts;
     late List<PostFirestore> userPosts;
+    late List<PostFirestore> challenges;
 
     late Map<MapSelectionOptions, List<PostFirestore>> expectedPostsForOption;
 
@@ -93,9 +95,24 @@ void main() {
       );
       await setPostsFirestore(userPosts, fakeFirestore);
 
+      challenges = [nearbyPosts.first, farPosts.first, userPosts.first];
+      for (final (i, post) in challenges.indexed) {
+        final challenge = FirestoreChallengeGenerator.generateFromPostId(
+          post.id,
+          // some are completed, others are not
+          i % 2 == 0,
+        );
+        await setChallenge(
+          fakeFirestore,
+          challenge,
+          testingUserFirestoreId,
+        );
+      }
+
       expectedPostsForOption = {
         MapSelectionOptions.nearby: nearbyPosts,
         MapSelectionOptions.myPosts: userPosts,
+        MapSelectionOptions.challenges: challenges,
       };
     });
 

--- a/test/views/pages/map/dynamic_map_test.dart
+++ b/test/views/pages/map/dynamic_map_test.dart
@@ -98,11 +98,12 @@ void main() {
       await setPostsFirestore(userPosts, fakeFirestore);
 
       challenges = [nearbyPosts.first, farPosts.first, userPosts.first];
+      // The second challenge is completed, the others are not
+      const completedChallengeIdx = 1;
       for (final (i, post) in challenges.indexed) {
         final challenge = FirestoreChallengeGenerator.generateFromPostId(
           post.id,
-          // The second challenge is completed, the others are not
-          i == 1,
+          i == completedChallengeIdx,
         );
         await setChallenge(
           fakeFirestore,
@@ -110,7 +111,9 @@ void main() {
           testingUserFirestoreId,
         );
       }
-      activeChallenges = challenges.whereNotIndexed((i, _) => i == 1).toList();
+      activeChallenges = challenges
+          .whereNotIndexed((i, _) => i == completedChallengeIdx)
+          .toList();
 
       expectedPostsForOption = {
         MapSelectionOptions.nearby: nearbyPosts,

--- a/test/views/pages/map/dynamic_map_test.dart
+++ b/test/views/pages/map/dynamic_map_test.dart
@@ -123,7 +123,7 @@ void main() {
       );
       await setPostsFirestore(userPosts, fakeFirestore);
 
-      challenges = [nearbyPosts.first, farPosts.first, userPosts.first];
+      challenges = [nearbyPosts.first, farPosts.first, farPosts.last];
       // The second challenge is completed, the others are not
       const completedChallengeIdx = 1;
       for (final (i, post) in challenges.indexed) {

--- a/test/views/pages/map/dynamic_map_test.dart
+++ b/test/views/pages/map/dynamic_map_test.dart
@@ -7,6 +7,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:mockito/mockito.dart";
 import "package:proxima/models/database/post/post_firestore.dart";
 import "package:proxima/models/ui/map_pin_details.dart";
+import "package:proxima/viewmodels/challenge_view_model.dart";
 import "package:proxima/viewmodels/map/map_pin_view_model.dart";
 import "package:proxima/viewmodels/option_selection/map_selection_options_view_model.dart";
 import "package:proxima/views/components/content/user_avatar/user_avatar.dart";
@@ -302,6 +303,18 @@ void main() {
         final backButton = find.byKey(LeadingBackButton.leadingBackButtonKey);
         expect(backButton, findsOneWidget);
         await tester.tap(backButton);
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testNavigation(
+      testTitle: "Pins refresh after challenge completion",
+      optionToTest: MapSelectionOptions.challenges,
+      expectedPinDelta: -1,
+      protocol: (tester, container) async {
+        container.read(challengeViewModelProvider.notifier).completeChallenge(
+              challenges.first.id,
+            );
         await tester.pumpAndSettle();
       },
     );

--- a/test/views/pages/map/dynamic_map_test.dart
+++ b/test/views/pages/map/dynamic_map_test.dart
@@ -1,4 +1,5 @@
 import "package:cloud_firestore/cloud_firestore.dart";
+import "package:collection/collection.dart";
 import "package:fake_cloud_firestore/fake_cloud_firestore.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
@@ -75,6 +76,7 @@ void main() {
     late List<PostFirestore> nearbyPosts;
     late List<PostFirestore> userPosts;
     late List<PostFirestore> challenges;
+    late List<PostFirestore> activeChallenges;
 
     late Map<MapSelectionOptions, List<PostFirestore>> expectedPostsForOption;
 
@@ -99,8 +101,8 @@ void main() {
       for (final (i, post) in challenges.indexed) {
         final challenge = FirestoreChallengeGenerator.generateFromPostId(
           post.id,
-          // some are completed, others are not
-          i % 2 == 0,
+          // The second challenge is completed, the others are not
+          i == 1,
         );
         await setChallenge(
           fakeFirestore,
@@ -108,11 +110,12 @@ void main() {
           testingUserFirestoreId,
         );
       }
+      activeChallenges = challenges.whereNotIndexed((i, _) => i == 1).toList();
 
       expectedPostsForOption = {
         MapSelectionOptions.nearby: nearbyPosts,
         MapSelectionOptions.myPosts: userPosts,
-        MapSelectionOptions.challenges: challenges,
+        MapSelectionOptions.challenges: activeChallenges,
       };
     });
 


### PR DESCRIPTION
Fixes #296.

This PR adds the functionality of the "Challenges" selection chip above the map. Only uncompleted challenges are displayed on the map. Once a challenge is completed, the pins are refreshed. This is also completely tested.

This PR strongly depends on the code I added in #320. I already had this PR in mind, so I made some very modular code and tests immediately, hence this PR size. 

Happy PR reviewing :)

Acceptance criteria:
- [x] Display the challenges of the user on the map
- [x] Enable the choice chip to choose between the available options and the newly added option