### PR TITLE
Ranking UI

### DIFF
--- a/lib/views/navigation/bottom_navigation_bar/navigation_bar_routes.dart
+++ b/lib/views/navigation/bottom_navigation_bar/navigation_bar_routes.dart
@@ -48,7 +48,7 @@ enum NavigationbarRoutes {
       case challenge:
         return const ChallengeList();
       case ranking:
-        return const RankingWidget();
+        return RankingWidget();
       case _:
         return const NotImplemented();
     }

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -35,19 +35,19 @@ class RankingCard extends StatelessWidget {
 
   final RankingElementDetails rankingElementDetails;
 
-  void onTapUserPopUp(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (BuildContext context) => UserProfilePopUp(
-        displayName: rankingElementDetails.userDisplayName,
-        username: rankingElementDetails.userUserName,
-        centauriPoints: rankingElementDetails.centauriPoints,
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
+    void onTapUserPopUp() {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) => UserProfilePopUp(
+          displayName: rankingElementDetails.userDisplayName,
+          username: rankingElementDetails.userUserName,
+          centauriPoints: rankingElementDetails.centauriPoints,
+        ),
+      );
+    }
+
     final cardColor = switch (rankingElementDetails.userRank) {
       1 => _rankOneColor,
       2 => _rankSecondColor,
@@ -117,7 +117,7 @@ class RankingCard extends StatelessWidget {
       clipBehavior: Clip.hardEdge,
       color: cardColor,
       child: InkWell(
-        onTap: () => onTapUserPopUp(context),
+        onTap: () => onTapUserPopUp(),
         child: Row(
           children: [
             userRankText,

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -9,13 +9,6 @@ import "package:proxima/views/components/content/user_avatar/user_avatar.dart";
 /// The card is clickable and opens a user profile pop-up.
 /// The card's color can be customized.
 class RankingCard extends StatelessWidget {
-  const RankingCard({
-    super.key,
-    required this.rankingElementDetails,
-  });
-
-  final RankingElementDetails rankingElementDetails;
-
   static const userRankrankTextKey = Key("userRankrankText");
   static const userRankDisplayNameTextKey = Key("userRankDisplayNameText");
   static const userRankCentauriPointsTextKey =
@@ -34,6 +27,13 @@ class RankingCard extends StatelessWidget {
   // This text is used when the parameter [userRank] of the
   // provided [RankingElementDetails] is null.
   static const _nullRankText = "---";
+
+  const RankingCard({
+    super.key,
+    required this.rankingElementDetails,
+  });
+
+  final RankingElementDetails rankingElementDetails;
 
   void onTapUserPopUp(BuildContext context) {
     showDialog(

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -18,7 +18,7 @@ class RankingCard extends StatelessWidget {
   // Sized box for the rank text to make sure that the text is centered
   // and that surrounding element spacing is consistent.
   // This width is allow to display three digits.
-  static const _sizedBoxRankWidth = 50.0;
+  static const _sizedBoxRankWidth = 35.0;
 
   static const _rankOneColor = Color.fromARGB(255, 255, 218, 75);
   static const _rankSecondColor = Color.fromARGB(255, 217, 218, 204);
@@ -65,9 +65,7 @@ class RankingCard extends StatelessWidget {
           rankingElementDetails.userRank == null
               ? _nullRankText
               : rankingElementDetails.userRank.toString(),
-          style: const TextStyle(
-            fontSize: 24,
-          ),
+          style: Theme.of(context).textTheme.bodyLarge,
         ),
       ),
     );
@@ -78,9 +76,6 @@ class RankingCard extends StatelessWidget {
         key: userRankDisplayNameTextKey,
         rankingElementDetails.userDisplayName,
         overflow: TextOverflow.ellipsis,
-        style: const TextStyle(
-          fontSize: 18,
-        ),
       ),
     );
 
@@ -107,9 +102,6 @@ class RankingCard extends StatelessWidget {
       child: Text(
         key: userRankCentauriPointsTextKey,
         rankingElementDetails.centauriPoints.toString(),
-        style: const TextStyle(
-          fontSize: 18,
-        ),
       ),
     );
 

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -113,21 +113,23 @@ class RankingCard extends StatelessWidget {
       ),
     );
 
+    final content = InkWell(
+      onTap: () => onTapUserPopUp(),
+      child: Row(
+        children: [
+          userRankText,
+          Expanded(
+            child: userInfo,
+          ),
+          centauriPointsText,
+        ],
+      ),
+    );
+
     return Card(
       clipBehavior: Clip.hardEdge,
       color: cardColor,
-      child: InkWell(
-        onTap: () => onTapUserPopUp(),
-        child: Row(
-          children: [
-            userRankText,
-            Expanded(
-              child: userInfo,
-            ),
-            centauriPointsText,
-          ],
-        ),
-      ),
+      child: content,
     );
   }
 }

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -73,9 +73,7 @@ class RankingCard extends StatelessWidget {
         child: Text(
           key: userRankrankTextKey,
           textAlign: TextAlign.center,
-          rankingElementDetails.userRank == null
-              ? _nullRankText
-              : rankingElementDetails.userRank.toString(),
+          rankingElementDetails.userRank?.toString() ?? _nullRankText,
           style: themeData.textTheme.bodyLarge,
         ),
       ),

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -1,0 +1,119 @@
+import "package:flutter/material.dart";
+import "package:proxima/models/ui/ranking/ranking_element_details.dart";
+import "package:proxima/models/ui/user_avatar_details.dart";
+import "package:proxima/views/components/content/publication_header/user_profile_pop_up.dart";
+import "package:proxima/views/components/content/user_avatar/user_avatar.dart";
+
+/// A class that displays a ranking card.
+/// The card displays the user's rank, display name, and centauri points.
+/// The card is clickable and opens a user profile pop-up.
+/// The card's color can be customized.
+class RankingCard extends StatelessWidget {
+  const RankingCard({
+    super.key,
+    required this.rankingElementDetails,
+  });
+
+  // Sized box for the rank text to make sure that the text is centered
+  // and that surrounding element spacing is consistent.
+  // This width is allow to display three digits.
+  static const sizedBoxRankWidth = 50.0;
+
+  static const rankOneColor = Color.fromARGB(255, 255, 218, 75);
+  static const rankSecondColor = Color.fromARGB(255, 217, 218, 204);
+  static const rankThirdColor = Color.fromARGB(255, 229, 153, 137);
+
+  final RankingElementDetails rankingElementDetails;
+
+  void onTapUserPopUp(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) => UserProfilePopUp(
+        displayName: rankingElementDetails.userDisplayName,
+        username: rankingElementDetails.userUserName,
+        centauriPoints: rankingElementDetails.centauriPoints,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cardColor = switch (rankingElementDetails.userRank) {
+      1 => rankOneColor,
+      2 => rankSecondColor,
+      3 => rankThirdColor,
+      _ => null,
+    };
+
+    final userRankText = Padding(
+      padding: const EdgeInsets.only(left: 10),
+      child: SizedBox(
+        width: sizedBoxRankWidth,
+        child: Text(
+          textAlign: TextAlign.center,
+          rankingElementDetails.userRank == null
+              ? "---"
+              : rankingElementDetails.userRank.toString(),
+          style: const TextStyle(
+            fontSize: 24,
+          ),
+        ),
+      ),
+    );
+
+    final userDisplayNameText = Padding(
+      padding: const EdgeInsets.only(left: 12, right: 16),
+      child: Text(
+        rankingElementDetails.userDisplayName,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          fontSize: 18,
+        ),
+      ),
+    );
+
+    final userDetails = UserAvatarDetails(
+      displayName: rankingElementDetails.userDisplayName,
+      userCentauriPoints: rankingElementDetails.centauriPoints,
+    );
+    final userInfo = Padding(
+      padding: const EdgeInsets.all(8),
+      child: Row(
+        children: [
+          UserAvatar(
+            details: userDetails,
+            radius: 22,
+          ),
+          Flexible(child: userDisplayNameText),
+        ],
+      ),
+    );
+
+    final centauriPointsText = Padding(
+      padding: const EdgeInsets.only(right: 10),
+      child: Text(
+        rankingElementDetails.centauriPoints.toString(),
+        style: const TextStyle(
+          fontSize: 18,
+        ),
+      ),
+    );
+
+    return Card(
+      clipBehavior: Clip.hardEdge,
+      color: cardColor,
+      child: InkWell(
+        onTap: () => onTapUserPopUp(context),
+        child: Row(
+          children: [
+            userRankText,
+            Expanded(
+              child: userInfo,
+            ),
+            centauriPointsText,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -14,6 +14,12 @@ class RankingCard extends StatelessWidget {
     required this.rankingElementDetails,
   });
 
+  static const userRankrankTextKey = Key("userRankrankText");
+  static const userRankDisplayNameTextKey = Key("userRankDisplayNameText");
+  static const userRankCentauriPointsTextKey =
+      Key("userRankCentauriPointsText");
+  static const userRankAvatarKey = Key("userRankAvatar");
+
   // Sized box for the rank text to make sure that the text is centered
   // and that surrounding element spacing is consistent.
   // This width is allow to display three digits.
@@ -50,6 +56,7 @@ class RankingCard extends StatelessWidget {
       child: SizedBox(
         width: sizedBoxRankWidth,
         child: Text(
+          key: userRankrankTextKey,
           textAlign: TextAlign.center,
           rankingElementDetails.userRank == null
               ? "---"
@@ -64,6 +71,7 @@ class RankingCard extends StatelessWidget {
     final userDisplayNameText = Padding(
       padding: const EdgeInsets.only(left: 12, right: 16),
       child: Text(
+        key: userRankDisplayNameTextKey,
         rankingElementDetails.userDisplayName,
         overflow: TextOverflow.ellipsis,
         style: const TextStyle(
@@ -81,6 +89,7 @@ class RankingCard extends StatelessWidget {
       child: Row(
         children: [
           UserAvatar(
+            key: userRankAvatarKey,
             details: userDetails,
             radius: 22,
           ),
@@ -92,6 +101,7 @@ class RankingCard extends StatelessWidget {
     final centauriPointsText = Padding(
       padding: const EdgeInsets.only(right: 10),
       child: Text(
+        key: userRankCentauriPointsTextKey,
         rankingElementDetails.centauriPoints.toString(),
         style: const TextStyle(
           fontSize: 18,

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -29,6 +29,10 @@ class RankingCard extends StatelessWidget {
   static const rankSecondColor = Color.fromARGB(255, 217, 218, 204);
   static const rankThirdColor = Color.fromARGB(255, 229, 153, 137);
 
+  // This text is used when the parameter [userRank] of the
+  // provided [RankingElementDetails] is null.
+  static const _nullRankText = "---";
+
   final RankingElementDetails rankingElementDetails;
 
   void onTapUserPopUp(BuildContext context) {
@@ -59,7 +63,7 @@ class RankingCard extends StatelessWidget {
           key: userRankrankTextKey,
           textAlign: TextAlign.center,
           rankingElementDetails.userRank == null
-              ? "---"
+              ? _nullRankText
               : rankingElementDetails.userRank.toString(),
           style: const TextStyle(
             fontSize: 24,

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -14,6 +14,8 @@ class RankingCard extends StatelessWidget {
     required this.rankingElementDetails,
   });
 
+  final RankingElementDetails rankingElementDetails;
+
   static const userRankrankTextKey = Key("userRankrankText");
   static const userRankDisplayNameTextKey = Key("userRankDisplayNameText");
   static const userRankCentauriPointsTextKey =
@@ -32,8 +34,6 @@ class RankingCard extends StatelessWidget {
   // This text is used when the parameter [userRank] of the
   // provided [RankingElementDetails] is null.
   static const _nullRankText = "---";
-
-  final RankingElementDetails rankingElementDetails;
 
   void onTapUserPopUp(BuildContext context) {
     showDialog(

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -20,9 +20,16 @@ class RankingCard extends StatelessWidget {
   // This width is allow to display three digits.
   static const _sizedBoxRankWidth = 35.0;
 
-  static const _rankOneColor = Color.fromARGB(255, 255, 218, 75);
-  static const _rankSecondColor = Color.fromARGB(255, 217, 218, 204);
-  static const _rankThirdColor = Color.fromARGB(255, 229, 153, 137);
+  // Colors for the ranking card.
+  // The colors are different for light and dark mode.
+  // The first element of the tuple is the color for light mode,
+  // the second element is the color for dark mode.
+  static const _rankOneColor =
+      (Color.fromARGB(255, 255, 218, 75), Color.fromARGB(255, 206, 176, 60));
+  static const _rankSecondColor =
+      (Color.fromARGB(255, 217, 218, 204), Color.fromARGB(255, 161, 161, 151));
+  static const _rankThirdColor =
+      (Color.fromARGB(255, 229, 153, 137), Color.fromARGB(255, 138, 89, 80));
 
   // This text is used when the parameter [userRank] of the
   // provided [RankingElementDetails] is null.
@@ -37,6 +44,9 @@ class RankingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final isLightMode = themeData.brightness == Brightness.light;
+
     /// On tap function to open the user profile pop-up.
     onTapUserPopUp() => {
           showDialog(
@@ -50,9 +60,9 @@ class RankingCard extends StatelessWidget {
         };
 
     final cardColor = switch (rankingElementDetails.userRank) {
-      1 => _rankOneColor,
-      2 => _rankSecondColor,
-      3 => _rankThirdColor,
+      1 => isLightMode ? _rankOneColor.$1 : _rankOneColor.$2,
+      2 => isLightMode ? _rankSecondColor.$1 : _rankSecondColor.$2,
+      3 => isLightMode ? _rankThirdColor.$1 : _rankThirdColor.$2,
       _ => null,
     };
 
@@ -66,7 +76,7 @@ class RankingCard extends StatelessWidget {
           rankingElementDetails.userRank == null
               ? _nullRankText
               : rankingElementDetails.userRank.toString(),
-          style: Theme.of(context).textTheme.bodyLarge,
+          style: themeData.textTheme.bodyLarge,
         ),
       ),
     );

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -4,7 +4,7 @@ import "package:proxima/models/ui/user_avatar_details.dart";
 import "package:proxima/views/components/content/publication_header/user_profile_pop_up.dart";
 import "package:proxima/views/components/content/user_avatar/user_avatar.dart";
 
-/// A class that displays a ranking card.
+/// A widget that displays a ranking card.
 /// The card displays the user's rank, display name, and centauri points.
 /// The card is clickable and opens a user profile pop-up.
 /// The card's color can be customized.

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -25,11 +25,11 @@ class RankingCard extends StatelessWidget {
   // Sized box for the rank text to make sure that the text is centered
   // and that surrounding element spacing is consistent.
   // This width is allow to display three digits.
-  static const sizedBoxRankWidth = 50.0;
+  static const _sizedBoxRankWidth = 50.0;
 
-  static const rankOneColor = Color.fromARGB(255, 255, 218, 75);
-  static const rankSecondColor = Color.fromARGB(255, 217, 218, 204);
-  static const rankThirdColor = Color.fromARGB(255, 229, 153, 137);
+  static const _rankOneColor = Color.fromARGB(255, 255, 218, 75);
+  static const _rankSecondColor = Color.fromARGB(255, 217, 218, 204);
+  static const _rankThirdColor = Color.fromARGB(255, 229, 153, 137);
 
   // This text is used when the parameter [userRank] of the
   // provided [RankingElementDetails] is null.
@@ -49,16 +49,16 @@ class RankingCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cardColor = switch (rankingElementDetails.userRank) {
-      1 => rankOneColor,
-      2 => rankSecondColor,
-      3 => rankThirdColor,
+      1 => _rankOneColor,
+      2 => _rankSecondColor,
+      3 => _rankThirdColor,
       _ => null,
     };
 
     final userRankText = Padding(
       padding: const EdgeInsets.only(left: 10),
       child: SizedBox(
-        width: sizedBoxRankWidth,
+        width: _sizedBoxRankWidth,
         child: Text(
           key: userRankrankTextKey,
           textAlign: TextAlign.center,

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -24,12 +24,22 @@ class RankingCard extends StatelessWidget {
   // The colors are different for light and dark mode.
   // The first element of the tuple is the color for light mode,
   // the second element is the color for dark mode.
-  static const _rankOneColor =
-      (Color.fromARGB(255, 255, 218, 75), Color.fromARGB(255, 206, 176, 60));
-  static const _rankSecondColor =
-      (Color.fromARGB(255, 217, 218, 204), Color.fromARGB(255, 161, 161, 151));
-  static const _rankThirdColor =
-      (Color.fromARGB(255, 229, 153, 137), Color.fromARGB(255, 138, 89, 80));
+  //
+  // This list is ordered by rank.
+  static const _rankingColors = [
+    (
+      Color.fromARGB(255, 255, 218, 75),
+      Color.fromARGB(255, 206, 176, 60)
+    ), // Rank 1
+    (
+      Color.fromARGB(255, 217, 218, 204),
+      Color.fromARGB(255, 161, 161, 151)
+    ), // Rank 2
+    (
+      Color.fromARGB(255, 229, 153, 137),
+      Color.fromARGB(255, 138, 89, 80)
+    ), // Rank 3
+  ];
 
   // This text is used when the parameter [userRank] of the
   // provided [RankingElementDetails] is null.
@@ -46,6 +56,7 @@ class RankingCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
     final isLightMode = themeData.brightness == Brightness.light;
+    final userRank = rankingElementDetails.userRank;
 
     /// On tap function to open the user profile pop-up.
     onTapUserPopUp() => {
@@ -59,12 +70,9 @@ class RankingCard extends StatelessWidget {
           ),
         };
 
-    final cardColor = switch (rankingElementDetails.userRank) {
-      1 => isLightMode ? _rankOneColor.$1 : _rankOneColor.$2,
-      2 => isLightMode ? _rankSecondColor.$1 : _rankSecondColor.$2,
-      3 => isLightMode ? _rankThirdColor.$1 : _rankThirdColor.$2,
-      _ => null,
-    };
+    final cardColorTuple =
+        userRank != null ? _rankingColors.elementAtOrNull(userRank - 1) : null;
+    final cardColor = isLightMode ? cardColorTuple?.$1 : cardColorTuple?.$2;
 
     final userRankText = Padding(
       padding: const EdgeInsets.only(left: 10),
@@ -73,7 +81,7 @@ class RankingCard extends StatelessWidget {
         child: Text(
           key: userRankrankTextKey,
           textAlign: TextAlign.center,
-          rankingElementDetails.userRank?.toString() ?? _nullRankText,
+          userRank?.toString() ?? _nullRankText,
           style: themeData.textTheme.bodyLarge,
         ),
       ),

--- a/lib/views/pages/home/content/ranking/ranking_card.dart
+++ b/lib/views/pages/home/content/ranking/ranking_card.dart
@@ -37,16 +37,17 @@ class RankingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    void onTapUserPopUp() {
-      showDialog(
-        context: context,
-        builder: (BuildContext context) => UserProfilePopUp(
-          displayName: rankingElementDetails.userDisplayName,
-          username: rankingElementDetails.userUserName,
-          centauriPoints: rankingElementDetails.centauriPoints,
-        ),
-      );
-    }
+    /// On tap function to open the user profile pop-up.
+    onTapUserPopUp() => {
+          showDialog(
+            context: context,
+            builder: (BuildContext context) => UserProfilePopUp(
+              displayName: rankingElementDetails.userDisplayName,
+              username: rankingElementDetails.userUserName,
+              centauriPoints: rankingElementDetails.centauriPoints,
+            ),
+          ),
+        };
 
     final cardColor = switch (rankingElementDetails.userRank) {
       1 => _rankOneColor,

--- a/lib/views/pages/home/content/ranking/ranking_list.dart
+++ b/lib/views/pages/home/content/ranking/ranking_list.dart
@@ -1,0 +1,33 @@
+import "package:flutter/material.dart";
+import "package:proxima/models/ui/ranking/ranking_details.dart";
+import "package:proxima/views/helpers/types.dart";
+import "package:proxima/views/pages/home/content/ranking/ranking_card.dart";
+
+/// A class that displays a list of ranking cards.
+class RankingList extends StatelessWidget {
+  const RankingList({
+    super.key,
+    required this.rankingDetails,
+    required this.onRefresh,
+  });
+
+  final RankingDetails rankingDetails;
+  final FutureVoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    // Build the ranking cards
+    final rankingCards = rankingDetails.rankElementDetailsList
+        .map(
+          (rankingElementDetails) => RankingCard(
+            rankingElementDetails: rankingElementDetails,
+          ),
+        )
+        .toList();
+
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: ListView(children: rankingCards),
+    );
+  }
+}

--- a/lib/views/pages/home/content/ranking/ranking_list.dart
+++ b/lib/views/pages/home/content/ranking/ranking_list.dart
@@ -3,7 +3,7 @@ import "package:proxima/models/ui/ranking/ranking_details.dart";
 import "package:proxima/views/helpers/types.dart";
 import "package:proxima/views/pages/home/content/ranking/ranking_card.dart";
 
-/// A class that displays a list of ranking cards.
+/// A widget that displays a list of ranking cards.
 class RankingList extends StatelessWidget {
   const RankingList({
     super.key,

--- a/lib/views/pages/home/content/ranking/ranking_widget.dart
+++ b/lib/views/pages/home/content/ranking/ranking_widget.dart
@@ -9,6 +9,9 @@ import "package:proxima/views/pages/home/content/ranking/ranking_list.dart";
 class RankingWidget extends StatelessWidget {
   const RankingWidget({super.key});
 
+  static const rankingListKey = Key("rankingList");
+  static const userRankingCardKey = Key("userRankingCard");
+
   // Creating mock data for the ranking list
   final List<Map<String, int>> userList = const [
     {"user123": 9420},
@@ -53,6 +56,7 @@ class RankingWidget extends StatelessWidget {
       children: [
         Flexible(
           child: RankingList(
+            key: rankingListKey,
             rankingDetails: rankingDetails,
             onRefresh: () async {
               //TODO: Add refresh logic
@@ -61,6 +65,7 @@ class RankingWidget extends StatelessWidget {
         ),
         const Divider(),
         RankingCard(
+          key: userRankingCardKey,
           rankingElementDetails: rankingDetails.userRankElementDetails,
         ),
         const SizedBox(height: 5),

--- a/lib/views/pages/home/content/ranking/ranking_widget.dart
+++ b/lib/views/pages/home/content/ranking/ranking_widget.dart
@@ -5,7 +5,7 @@ import "package:proxima/models/ui/ranking/ranking_element_details.dart";
 import "package:proxima/views/pages/home/content/ranking/ranking_card.dart";
 import "package:proxima/views/pages/home/content/ranking/ranking_list.dart";
 
-/// A class that displays the ranking widget.
+/// A widget that displays the ranking widget.
 class RankingWidget extends StatelessWidget {
   const RankingWidget({super.key});
 

--- a/lib/views/pages/home/content/ranking/ranking_widget.dart
+++ b/lib/views/pages/home/content/ranking/ranking_widget.dart
@@ -10,10 +10,10 @@ class RankingWidget extends StatelessWidget {
   static const rankingListKey = Key("rankingList");
   static const userRankingCardKey = Key("userRankingCard");
 
-  const RankingWidget({super.key});
+  RankingWidget({super.key});
 
   // Creating mock data for the ranking list
-  final List<Map<String, int>> userList = const [
+  static const List<Map<String, int>> userList = [
     {"user123": 9420},
     {"johnDoe": 8370},
     {"janeSmith": 6550},
@@ -32,20 +32,19 @@ class RankingWidget extends StatelessWidget {
     userRank: null,
   );
 
+  final rankElementDetailsList = userList
+      .mapIndexed(
+        (index, user) => RankingElementDetails(
+          userDisplayName: user.keys.first,
+          userUserName: "u_${user.keys.first}",
+          centauriPoints: user.values.first,
+          userRank: index + 1,
+        ),
+      )
+      .toList();
+
   @override
   Widget build(BuildContext context) {
-    //Mock data creation (should be replaced with actual data)
-    final rankElementDetailsList = userList
-        .mapIndexed(
-          (index, user) => RankingElementDetails(
-            userDisplayName: user.keys.first,
-            userUserName: "u_${user.keys.first}",
-            centauriPoints: user.values.first,
-            userRank: index + 1,
-          ),
-        )
-        .toList();
-
     final rankingDetails = RankingDetails(
       rankElementDetailsList: rankElementDetailsList,
       userRankElementDetails: userRankElementDetails,

--- a/lib/views/pages/home/content/ranking/ranking_widget.dart
+++ b/lib/views/pages/home/content/ranking/ranking_widget.dart
@@ -7,10 +7,10 @@ import "package:proxima/views/pages/home/content/ranking/ranking_list.dart";
 
 /// A widget that displays the ranking widget.
 class RankingWidget extends StatelessWidget {
-  const RankingWidget({super.key});
-
   static const rankingListKey = Key("rankingList");
   static const userRankingCardKey = Key("userRankingCard");
+
+  const RankingWidget({super.key});
 
   // Creating mock data for the ranking list
   final List<Map<String, int>> userList = const [

--- a/lib/views/pages/home/content/ranking/ranking_widget.dart
+++ b/lib/views/pages/home/content/ranking/ranking_widget.dart
@@ -45,6 +45,7 @@ class RankingWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    //TODO: Replace with view model RankingDetails getter logic
     final rankingDetails = RankingDetails(
       rankElementDetailsList: rankElementDetailsList,
       userRankElementDetails: userRankElementDetails,

--- a/lib/views/pages/home/content/ranking/ranking_widget.dart
+++ b/lib/views/pages/home/content/ranking/ranking_widget.dart
@@ -1,10 +1,70 @@
+import "package:collection/collection.dart";
 import "package:flutter/material.dart";
+import "package:proxima/models/ui/ranking/ranking_details.dart";
+import "package:proxima/models/ui/ranking/ranking_element_details.dart";
+import "package:proxima/views/pages/home/content/ranking/ranking_card.dart";
+import "package:proxima/views/pages/home/content/ranking/ranking_list.dart";
 
+/// A class that displays the ranking widget.
 class RankingWidget extends StatelessWidget {
   const RankingWidget({super.key});
 
+  // Creating mock data for the ranking list
+  final List<Map<String, int>> userList = const [
+    {"user123": 9420},
+    {"johnDoe": 8370},
+    {"janeSmith": 6550},
+    {"coolGuy": 5280},
+    {"happyGal": 3000},
+    {"superman": 2310},
+    {"batman": 1530},
+    {"wonderWoman": 420},
+  ];
+
+  final RankingElementDetails userRankElementDetails =
+      const RankingElementDetails(
+    userDisplayName: "You",
+    userUserName: "U_You",
+    centauriPoints: 100,
+    userRank: null,
+  );
+
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text("Ranking"));
+    //Mock data creation (should be replaced with actual data)
+    final rankElementDetailsList = userList
+        .mapIndexed(
+          (index, user) => RankingElementDetails(
+            userDisplayName: user.keys.first,
+            userUserName: "u_${user.keys.first}",
+            centauriPoints: user.values.first,
+            userRank: index + 1,
+          ),
+        )
+        .toList();
+
+    final rankingDetails = RankingDetails(
+      rankElementDetailsList: rankElementDetailsList,
+      userRankElementDetails: userRankElementDetails,
+    );
+
+    //TODO: Add Circular value waiting on data.
+    return Column(
+      children: [
+        Flexible(
+          child: RankingList(
+            rankingDetails: rankingDetails,
+            onRefresh: () async {
+              //TODO: Add refresh logic
+            },
+          ),
+        ),
+        const Divider(),
+        RankingCard(
+          rankingElementDetails: rankingDetails.userRankElementDetails,
+        ),
+        const SizedBox(height: 5),
+      ],
+    );
   }
 }

--- a/test/mocks/data/ranking_data.dart
+++ b/test/mocks/data/ranking_data.dart
@@ -1,0 +1,46 @@
+import "package:collection/collection.dart";
+import "package:proxima/models/ui/ranking/ranking_details.dart";
+import "package:proxima/models/ui/ranking/ranking_element_details.dart";
+
+import "firestore_user.dart";
+
+/// Mock user list for the ranking widget.
+final List<Map<String, int>> _rankingUserList = [
+  {"user123": 9420},
+  {"johnDoe": 8370},
+  {"janeSmith": 6550},
+  {"coolGuy": 5280},
+  {"happyGal": 3000},
+  {"superman": 2310},
+  {"batman": 1530},
+  {"wonderWoman": 420},
+];
+
+/// Create a list of [RankingElementDetails] from the mock user list.
+final List<RankingElementDetails> mockRankingElementDetailsList =
+    _rankingUserList
+        .mapIndexed(
+          (index, user) => RankingElementDetails(
+            userDisplayName: user.keys.first,
+            userUserName: "u_${user.keys.first}",
+            centauriPoints: user.values.first,
+            userRank: index + 1,
+          ),
+        )
+        .toList();
+
+/// Create a [RankingDetails] with the mock user list and a non-null current [userRank].
+final RankingDetails mockRankingDetailsWithtestUser = RankingDetails(
+  rankElementDetailsList: mockRankingElementDetailsList,
+  userRankElementDetails: testUserRankingElementDetails,
+);
+
+/// Create a [RankingElementDetails] for the testingUser with 0 centauri points.
+/// to stay consistent with the user list used to create the mock ranking details.
+final RankingElementDetails testUserRankingElementDetails =
+    RankingElementDetails(
+  userDisplayName: testingUserData.displayName,
+  userUserName: testingUserData.username,
+  centauriPoints: 0,
+  userRank: 9,
+);

--- a/test/views/pages/home/content/ranking/static_ranking_list_test.dart
+++ b/test/views/pages/home/content/ranking/static_ranking_list_test.dart
@@ -62,42 +62,6 @@ void main() {
         findsNWidgets(mockRankingElementDetailsList.length),
       );
 
-      //Check that the card color corresponds to the expected color
-      const expectedRankOneColor = Color.fromARGB(255, 255, 218, 75);
-      const expectedRrankSecondColor = Color.fromARGB(255, 217, 218, 204);
-      const expectedRrankThirdColor = Color.fromARGB(255, 229, 153, 137);
-
-      final expectedColorsRank = {
-        1: expectedRankOneColor,
-        2: expectedRrankSecondColor,
-        3: expectedRrankThirdColor,
-      };
-
-      expectedColorsRank.forEach(
-        (rank, expectedColor) {
-          // Check that the color of the rank card containing
-          // the user with the rank [rank] is of the right color
-          final rankCardTextFinder = find.descendant(
-            of: rankingCards,
-            matching: find.text(rank.toString()),
-          );
-          expect(rankCardTextFinder, findsOneWidget);
-
-          // Get the card containing the user with the rank [rank]
-          final rankCardFinder = find.ancestor(
-            of: rankCardTextFinder,
-            matching: find.byType(Card),
-          );
-
-          expect(rankCardFinder, findsOneWidget);
-
-          final rankCardWidget = tester.widget(rankCardFinder);
-
-          // Check that the color matches the expected color
-          expect((rankCardWidget as Card).color, expectedColor);
-        },
-      );
-
       // Click on the first user ranking card
       await tester.tap(rankingCards.first);
       await tester.pumpAndSettle();

--- a/test/views/pages/home/content/ranking/static_ranking_list_test.dart
+++ b/test/views/pages/home/content/ranking/static_ranking_list_test.dart
@@ -1,0 +1,110 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:proxima/views/components/content/publication_header/user_profile_pop_up.dart";
+import "package:proxima/views/pages/home/content/ranking/ranking_card.dart";
+import "package:proxima/views/pages/home/content/ranking/ranking_list.dart";
+
+import "../../../../../mocks/data/ranking_data.dart";
+
+void main() {
+  testWidgets(
+    "Check that all the ranking elements are displayed correctly",
+    (tester) async {
+      final rankingListWidget = MaterialApp(
+        home: RankingList(
+          rankingDetails: mockRankingDetailsWithtestUser,
+          onRefresh: () async {},
+        ),
+      );
+
+      await tester.pumpWidget(rankingListWidget);
+      await tester.pumpAndSettle();
+
+      // Check that the ranking list is displayed
+      final rankingList = find.byType(RankingList);
+      expect(rankingList, findsOneWidget);
+
+      // Check that the ranking cards are displayed
+      // The additional card is for the current user's ranking card.
+      final rankingCards = find.byType(RankingCard);
+      expect(
+        rankingCards,
+        findsNWidgets(mockRankingElementDetailsList.length),
+      );
+
+      // Check that the user ranks are displayed
+      final userRankTexts = find.byKey(RankingCard.userRankrankTextKey);
+      expect(
+        userRankTexts,
+        findsNWidgets(mockRankingElementDetailsList.length),
+      );
+
+      // Check that the user avatar are displayed
+      final userAvatars = find.byKey(RankingCard.userRankAvatarKey);
+      expect(
+        userAvatars,
+        findsNWidgets(mockRankingElementDetailsList.length),
+      );
+
+      // Check that the display names are displayed
+      final userDisplayNameTexts =
+          find.byKey(RankingCard.userRankDisplayNameTextKey);
+      expect(
+        userDisplayNameTexts,
+        findsNWidgets(mockRankingElementDetailsList.length),
+      );
+
+      // Check that the centauri points are displayed
+      final centauriPointsTexts =
+          find.byKey(RankingCard.userRankCentauriPointsTextKey);
+      expect(
+        centauriPointsTexts,
+        findsNWidgets(mockRankingElementDetailsList.length),
+      );
+
+      //Check that the card color corresponds to the expected color
+      const expectedRankOneColor = Color.fromARGB(255, 255, 218, 75);
+      const expectedRrankSecondColor = Color.fromARGB(255, 217, 218, 204);
+      const expectedRrankThirdColor = Color.fromARGB(255, 229, 153, 137);
+
+      final expectedColorsRank = {
+        1: expectedRankOneColor,
+        2: expectedRrankSecondColor,
+        3: expectedRrankThirdColor,
+      };
+
+      expectedColorsRank.forEach(
+        (rank, expectedColor) {
+          // Check that the color of the rank card containing
+          // the user with the rank [rank] is of the right color
+          final rankCardTextFinder = find.descendant(
+            of: rankingCards,
+            matching: find.text(rank.toString()),
+          );
+          expect(rankCardTextFinder, findsOneWidget);
+
+          // Get the card containing the user with the rank [rank]
+          final rankCardFinder = find.ancestor(
+            of: rankCardTextFinder,
+            matching: find.byType(Card),
+          );
+
+          expect(rankCardFinder, findsOneWidget);
+
+          final rankCardWidget = tester.widget(rankCardFinder);
+
+          // Check that the color matches the expected color
+          expect((rankCardWidget as Card).color, expectedColor);
+        },
+      );
+
+      // Click on the first user ranking card
+      await tester.tap(rankingCards.first);
+      await tester.pumpAndSettle();
+
+      // Check that the profile page pop up is displayed
+      final profilePopUp = find.byType(UserProfilePopUp);
+      expect(profilePopUp, findsOneWidget);
+    },
+  );
+}

--- a/test/views/pages/home/content/ranking/static_ranking_list_test.dart
+++ b/test/views/pages/home/content/ranking/static_ranking_list_test.dart
@@ -7,68 +7,70 @@ import "package:proxima/views/pages/home/content/ranking/ranking_list.dart";
 import "../../../../../mocks/data/ranking_data.dart";
 
 void main() {
-  testWidgets(
-    "Check that all the ranking elements are displayed correctly",
-    (tester) async {
-      final rankingListWidget = MaterialApp(
-        home: RankingList(
-          rankingDetails: mockRankingDetailsWithtestUser,
-          onRefresh: () async {},
-        ),
-      );
+  group("Widgets display", () {
+    testWidgets(
+      "Display ranking elements",
+      (tester) async {
+        final rankingListWidget = MaterialApp(
+          home: RankingList(
+            rankingDetails: mockRankingDetailsWithtestUser,
+            onRefresh: () async {},
+          ),
+        );
 
-      await tester.pumpWidget(rankingListWidget);
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(rankingListWidget);
+        await tester.pumpAndSettle();
 
-      // Check that the ranking list is displayed
-      final rankingList = find.byType(RankingList);
-      expect(rankingList, findsOneWidget);
+        // Check that the ranking list is displayed
+        final rankingList = find.byType(RankingList);
+        expect(rankingList, findsOneWidget);
 
-      // Check that the ranking cards are displayed
-      // The additional card is for the current user's ranking card.
-      final rankingCards = find.byType(RankingCard);
-      expect(
-        rankingCards,
-        findsNWidgets(mockRankingElementDetailsList.length),
-      );
+        // Check that the ranking cards are displayed
+        // The additional card is for the current user's ranking card.
+        final rankingCards = find.byType(RankingCard);
+        expect(
+          rankingCards,
+          findsNWidgets(mockRankingElementDetailsList.length),
+        );
 
-      // Check that the user ranks are displayed
-      final userRankTexts = find.byKey(RankingCard.userRankrankTextKey);
-      expect(
-        userRankTexts,
-        findsNWidgets(mockRankingElementDetailsList.length),
-      );
+        // Check that the user ranks are displayed
+        final userRankTexts = find.byKey(RankingCard.userRankrankTextKey);
+        expect(
+          userRankTexts,
+          findsNWidgets(mockRankingElementDetailsList.length),
+        );
 
-      // Check that the user avatar are displayed
-      final userAvatars = find.byKey(RankingCard.userRankAvatarKey);
-      expect(
-        userAvatars,
-        findsNWidgets(mockRankingElementDetailsList.length),
-      );
+        // Check that the user avatar are displayed
+        final userAvatars = find.byKey(RankingCard.userRankAvatarKey);
+        expect(
+          userAvatars,
+          findsNWidgets(mockRankingElementDetailsList.length),
+        );
 
-      // Check that the display names are displayed
-      final userDisplayNameTexts =
-          find.byKey(RankingCard.userRankDisplayNameTextKey);
-      expect(
-        userDisplayNameTexts,
-        findsNWidgets(mockRankingElementDetailsList.length),
-      );
+        // Check that the display names are displayed
+        final userDisplayNameTexts =
+            find.byKey(RankingCard.userRankDisplayNameTextKey);
+        expect(
+          userDisplayNameTexts,
+          findsNWidgets(mockRankingElementDetailsList.length),
+        );
 
-      // Check that the centauri points are displayed
-      final centauriPointsTexts =
-          find.byKey(RankingCard.userRankCentauriPointsTextKey);
-      expect(
-        centauriPointsTexts,
-        findsNWidgets(mockRankingElementDetailsList.length),
-      );
+        // Check that the centauri points are displayed
+        final centauriPointsTexts =
+            find.byKey(RankingCard.userRankCentauriPointsTextKey);
+        expect(
+          centauriPointsTexts,
+          findsNWidgets(mockRankingElementDetailsList.length),
+        );
 
-      // Click on the first user ranking card
-      await tester.tap(rankingCards.first);
-      await tester.pumpAndSettle();
+        // Click on the first user ranking card
+        await tester.tap(rankingCards.first);
+        await tester.pumpAndSettle();
 
-      // Check that the profile page pop up is displayed
-      final profilePopUp = find.byType(UserProfilePopUp);
-      expect(profilePopUp, findsOneWidget);
-    },
-  );
+        // Check that the profile page pop up is displayed
+        final profilePopUp = find.byType(UserProfilePopUp);
+        expect(profilePopUp, findsOneWidget);
+      },
+    );
+  });
 }

--- a/test/views/pages/home/content/ranking/static_ranking_widget_test.dart
+++ b/test/views/pages/home/content/ranking/static_ranking_widget_test.dart
@@ -5,35 +5,37 @@ import "package:proxima/views/pages/home/content/ranking/ranking_widget.dart";
 import "../../../../../mocks/providers/provider_homepage.dart";
 
 void main() {
-  testWidgets(
-    "Check that all the ranking elements are displayed correctly",
-    (tester) async {
-      await tester.pumpWidget(nonEmptyHomePageProvider);
-      await tester.pumpAndSettle();
+  group("Widgets display", () {
+    testWidgets(
+      "Display ranking elements",
+      (tester) async {
+        await tester.pumpWidget(nonEmptyHomePageProvider);
+        await tester.pumpAndSettle();
 
-      // Navigate to the ranking page
-      await tester.tap(find.text("Ranking"));
-      await tester.pumpAndSettle();
+        // Navigate to the ranking page
+        await tester.tap(find.text("Ranking"));
+        await tester.pumpAndSettle();
 
-      // Check that the ranking widget is displayed
-      final rankingWidget = find.byType(RankingWidget);
-      expect(rankingWidget, findsOneWidget);
+        // Check that the ranking widget is displayed
+        final rankingWidget = find.byType(RankingWidget);
+        expect(rankingWidget, findsOneWidget);
 
-      // Check that the ranking list is displayed
-      final rankingListWidget = find.byKey(RankingWidget.rankingListKey);
-      expect(rankingListWidget, findsOneWidget);
+        // Check that the ranking list is displayed
+        final rankingListWidget = find.byKey(RankingWidget.rankingListKey);
+        expect(rankingListWidget, findsOneWidget);
 
-      // Check that the user ranking card is displayed
-      final userRankingCard = find.byKey(RankingWidget.userRankingCardKey);
-      expect(userRankingCard, findsOneWidget);
+        // Check that the user ranking card is displayed
+        final userRankingCard = find.byKey(RankingWidget.userRankingCardKey);
+        expect(userRankingCard, findsOneWidget);
 
-      // Click on the user ranking card
-      await tester.tap(userRankingCard);
-      await tester.pumpAndSettle();
+        // Click on the user ranking card
+        await tester.tap(userRankingCard);
+        await tester.pumpAndSettle();
 
-      // Check that the profile page pop up is displayed
-      final profilePopUp = find.byType(UserProfilePopUp);
-      expect(profilePopUp, findsOneWidget);
-    },
-  );
+        // Check that the profile page pop up is displayed
+        final profilePopUp = find.byType(UserProfilePopUp);
+        expect(profilePopUp, findsOneWidget);
+      },
+    );
+  });
 }

--- a/test/views/pages/home/content/ranking/static_ranking_widget_test.dart
+++ b/test/views/pages/home/content/ranking/static_ranking_widget_test.dart
@@ -1,0 +1,39 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:proxima/views/components/content/publication_header/user_profile_pop_up.dart";
+import "package:proxima/views/pages/home/content/ranking/ranking_widget.dart";
+
+import "../../../../../mocks/providers/provider_homepage.dart";
+
+void main() {
+  testWidgets(
+    "Check that all the ranking elements are displayed correctly",
+    (tester) async {
+      await tester.pumpWidget(nonEmptyHomePageProvider);
+      await tester.pumpAndSettle();
+
+      // Navigate to the ranking page
+      await tester.tap(find.text("Ranking"));
+      await tester.pumpAndSettle();
+
+      // Check that the ranking widget is displayed
+      final rankingWidget = find.byType(RankingWidget);
+      expect(rankingWidget, findsOneWidget);
+
+      // Check that the ranking list is displayed
+      final rankingListWidget = find.byKey(RankingWidget.rankingListKey);
+      expect(rankingListWidget, findsOneWidget);
+
+      // Check that the user ranking card is displayed
+      final userRankingCard = find.byKey(RankingWidget.userRankingCardKey);
+      expect(userRankingCard, findsOneWidget);
+
+      // Click on the user ranking card
+      await tester.tap(userRankingCard);
+      await tester.pumpAndSettle();
+
+      // Check that the profile page pop up is displayed
+      final profilePopUp = find.byType(UserProfilePopUp);
+      expect(profilePopUp, findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
Fixes: #298 
This PR aims to provide the UI for the ranking page.

<img width="200" alt="image" src="https://github.com/ProximaEPFL/proxima/assets/53620532/c1acaa7b-4d91-4bed-abcc-82a5e941366c">

**Note:**  We are working with Lucas in parallel on the view and the view model. So we are trying to reduce the amount of conflicts on our tasks. In this PR, all the mock datas are in the view for the moment.

Acceptance Criteria:

 - [x] Create the UI foundation to display the leaderboard.
 - [x] Update the Penpot design accordingly.