### PR TITLE
Sort user comments on profile page

### DIFF
--- a/lib/models/database/user_comment/user_comment_data.dart
+++ b/lib/models/database/user_comment/user_comment_data.dart
@@ -30,7 +30,8 @@ class UserCommentData {
       return UserCommentData(
         parentPostId: PostIdFirestore(value: data[parentPostIdField]),
         content: data[contentField],
-        publicationTime: data[publicationTimeField],
+        publicationTime: data[publicationTimeField] ??
+            Timestamp.fromMillisecondsSinceEpoch(0),
       );
     } catch (e) {
       if (e is TypeError) {

--- a/lib/models/database/user_comment/user_comment_data.dart
+++ b/lib/models/database/user_comment/user_comment_data.dart
@@ -1,3 +1,4 @@
+import "package:cloud_firestore/cloud_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 
 /// This class represents the data required to display a user's comment
@@ -7,15 +8,19 @@ class UserCommentData {
   final PostIdFirestore parentPostId;
   static const String parentPostIdField = "parentPostId";
 
-  /// The reference contains the content of the comment to be displayed.
+  /// The reference contains the content and publication time of the comment to be displayed.
   /// This is to avoid having to fetch the comment data from the comment
   /// collection under the post every time we want to display the user's comments.
   final String content;
   static const String contentField = "content";
 
+  final Timestamp publicationTime;
+  static const String publicationTimeField = "publicationTime";
+
   const UserCommentData({
     required this.parentPostId,
     required this.content,
+    required this.publicationTime,
   });
 
   /// This method will create an instance of [UserCommentData] from the
@@ -25,6 +30,7 @@ class UserCommentData {
       return UserCommentData(
         parentPostId: PostIdFirestore(value: data[parentPostIdField]),
         content: data[contentField],
+        publicationTime: data[publicationTimeField],
       );
     } catch (e) {
       if (e is TypeError) {
@@ -43,6 +49,7 @@ class UserCommentData {
     return {
       parentPostIdField: parentPostId.value,
       contentField: content,
+      publicationTimeField: publicationTime,
     };
   }
 
@@ -50,9 +57,10 @@ class UserCommentData {
   bool operator ==(Object other) {
     return other is UserCommentData &&
         other.parentPostId == parentPostId &&
-        other.content == content;
+        other.content == content &&
+        other.publicationTime == publicationTime;
   }
 
   @override
-  int get hashCode => Object.hash(parentPostId, content);
+  int get hashCode => Object.hash(parentPostId, content, publicationTime);
 }

--- a/lib/services/database/comment/comment_repository_service.dart
+++ b/lib/services/database/comment/comment_repository_service.dart
@@ -58,6 +58,7 @@ class CommentRepositoryService {
     final userCommentData = UserCommentData(
       parentPostId: parentPostId,
       content: commentData.content,
+      publicationTime: commentData.publicationTime,
     );
 
     final userComment =

--- a/lib/viewmodels/user_comments_view_model.dart
+++ b/lib/viewmodels/user_comments_view_model.dart
@@ -17,7 +17,15 @@ class UserCommentViewModel extends AutoDisposeAsyncNotifier<UserCommentsState> {
     final user = ref.watch(validLoggedInUserIdProvider);
 
     final commentsFirestore = await userCommentRepository.getUserComments(user);
-    final comments = commentsFirestore.map((comment) {
+
+    // Sort the comments from latest to oldest
+    final sortedCommentsFirestore = commentsFirestore.toList()
+      ..sort(
+        (commentA, commentB) => commentB.data.publicationTime
+            .compareTo(commentA.data.publicationTime),
+      );
+
+    final comments = sortedCommentsFirestore.map((comment) {
       final userComment = UserCommentDetails(
         commentId: comment.id,
         parentPostId: comment.data.parentPostId,

--- a/lib/viewmodels/user_comments_view_model.dart
+++ b/lib/viewmodels/user_comments_view_model.dart
@@ -1,3 +1,4 @@
+import "package:collection/collection.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:proxima/models/database/comment/comment_id_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
@@ -19,11 +20,10 @@ class UserCommentViewModel extends AutoDisposeAsyncNotifier<UserCommentsState> {
     final commentsFirestore = await userCommentRepository.getUserComments(user);
 
     // Sort the comments from latest to oldest
-    final sortedCommentsFirestore = commentsFirestore.toList()
-      ..sort(
-        (commentA, commentB) => commentB.data.publicationTime
-            .compareTo(commentA.data.publicationTime),
-      );
+    final sortedCommentsFirestore = commentsFirestore.toList().sorted(
+          (commentA, commentB) => commentB.data.publicationTime
+              .compareTo(commentA.data.publicationTime),
+        );
 
     final comments = sortedCommentsFirestore.map((comment) {
       final userComment = UserCommentDetails(

--- a/test/mocks/data/firestore_comment.dart
+++ b/test/mocks/data/firestore_comment.dart
@@ -121,6 +121,7 @@ class CommentFirestoreGenerator {
     final userCommentData = UserCommentData(
       parentPostId: postId,
       content: comment.data.content,
+      publicationTime: comment.data.publicationTime,
     );
     return UserCommentFirestore(id: comment.id, data: userCommentData);
   }

--- a/test/mocks/data/user_comment_data.dart
+++ b/test/mocks/data/user_comment_data.dart
@@ -1,5 +1,6 @@
 import "dart:math";
 
+import "package:cloud_firestore/cloud_firestore.dart";
 import "package:proxima/models/database/post/post_id_firestore.dart";
 import "package:proxima/models/database/user_comment/user_comment_data.dart";
 
@@ -15,15 +16,18 @@ class UserCommentDataGenerator {
   }
 
   /// Create a random mock [UserCommentData] instance.
-  /// The [parentPostId] and [content] can be provided to avoid randomness.
+  /// The [parentPostId], [content] or [publicationTime] can be provided to avoid randomness.
   UserCommentData generateUserCommentData({
     PostIdFirestore? parentPostId,
     String? content,
+    Timestamp? publicationTime,
   }) {
     return UserCommentData(
       parentPostId: parentPostId ??
           PostIdFirestore(value: "parent_post_id_${_random.nextInt(100)}"),
       content: content ?? "content_${_random.nextInt(100)}",
+      publicationTime: publicationTime ??
+          Timestamp.fromMillisecondsSinceEpoch(_random.nextInt(1000000000)),
     );
   }
 }

--- a/test/models/database/user_comment/user_comment_data_test.dart
+++ b/test/models/database/user_comment/user_comment_data_test.dart
@@ -18,6 +18,7 @@ void main() {
       final expectedHash = Object.hash(
         userCommentData.parentPostId,
         userCommentData.content,
+        userCommentData.publicationTime,
       );
       final actualHash = userCommentData.hashCode;
       expect(actualHash, expectedHash);
@@ -30,6 +31,7 @@ void main() {
       final otherUserCommentData = UserCommentData(
         parentPostId: userCommentData.parentPostId,
         content: userCommentData.content,
+        publicationTime: userCommentData.publicationTime,
       );
       expect(userCommentData, otherUserCommentData);
     });

--- a/test/viewmodels/user_comment_view_model_test.dart
+++ b/test/viewmodels/user_comment_view_model_test.dart
@@ -89,5 +89,11 @@ void main() {
         }
       });
     });
+
+    test("Empty comments are exposed correctly", () async {
+      final comments =
+          await container.read(userCommentsViewModelProvider.future);
+      expect(comments, isEmpty);
+    });
   });
 }

--- a/test/viewmodels/user_comment_view_model_test.dart
+++ b/test/viewmodels/user_comment_view_model_test.dart
@@ -1,0 +1,93 @@
+import "package:fake_cloud_firestore/fake_cloud_firestore.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:proxima/models/database/comment/comment_firestore.dart";
+import "package:proxima/models/database/user/user_id_firestore.dart";
+import "package:proxima/models/ui/user_comment_details.dart";
+import "package:proxima/services/database/comment/comment_repository_service.dart";
+import "package:proxima/services/database/firestore_service.dart";
+import "package:proxima/viewmodels/login_view_model.dart";
+import "package:proxima/viewmodels/user_comments_view_model.dart";
+
+import "../mocks/data/firestore_comment.dart";
+import "../mocks/data/firestore_user.dart";
+
+void main() {
+  group("Testing user comment view model", () {
+    late FakeFirebaseFirestore firestore;
+    late CommentRepositoryService commentRepository;
+    late CommentFirestoreGenerator commentGenerator;
+
+    late ProviderContainer container;
+    late UserIdFirestore userId;
+
+    setUp(() async {
+      firestore = FakeFirebaseFirestore();
+      commentGenerator = CommentFirestoreGenerator();
+
+      userId = testingUserFirestoreId;
+
+      container = ProviderContainer(
+        overrides: [
+          firestoreProvider.overrideWithValue(firestore),
+          loggedInUserIdProvider.overrideWithValue(userId),
+        ],
+      );
+
+      commentRepository = container.read(commentRepositoryServiceProvider);
+    });
+
+    group("Ordering", () {
+      /// Get the [CommentFirestore] from the list [comments] that corresponds
+      /// to the [userCommentDetails].
+      CommentFirestore getCorrespondingComment(
+        UserCommentDetails userCommentDetails,
+        List<CommentFirestore> comments,
+      ) {
+        // Check that the comment list contains exactly one comment with the same id
+        final correspondingComments = comments.where(
+          (comment) => comment.id == userCommentDetails.commentId,
+        );
+        expect(correspondingComments, hasLength(1));
+
+        return correspondingComments.first;
+      }
+
+      test("Comments are ordered from latest to oldest", () async {
+        const nbComments = 50;
+
+        // Add comments to the firestore
+        final (commentsFirestore, _) =
+            await commentGenerator.addCommentsForUser(
+          nbComments,
+          userId,
+          commentRepository,
+          firestore,
+        );
+
+        // Get the user comments
+        final commentDetails =
+            await container.read(userCommentsViewModelProvider.future);
+        expect(commentDetails, hasLength(nbComments));
+
+        // Check that the comments are ordered from latest to oldest
+        for (var i = 0; i < commentDetails.length - 1; i++) {
+          final commentDetailsAbove = commentDetails[i];
+          final commentDetailsBelow = commentDetails[i + 1];
+
+          final commentAbove =
+              getCorrespondingComment(commentDetailsAbove, commentsFirestore);
+          final commentBelow =
+              getCorrespondingComment(commentDetailsBelow, commentsFirestore);
+
+          expect(
+            commentAbove.data.publicationTime.microsecondsSinceEpoch,
+            greaterThanOrEqualTo(
+              commentBelow.data.publicationTime.microsecondsSinceEpoch,
+            ),
+          );
+        }
+      });
+    });
+  });
+}

--- a/test/viewmodels/user_comment_view_model_test.dart
+++ b/test/viewmodels/user_comment_view_model_test.dart
@@ -95,5 +95,33 @@ void main() {
           await container.read(userCommentsViewModelProvider.future);
       expect(comments, isEmpty);
     });
+
+    test("Single commment is exposed correctly", () async {
+      // Add a single comment to firestore
+      final (commentsFirestore, userCommentsFirestore) =
+          await commentGenerator.addCommentsForUser(
+        1,
+        userId,
+        commentRepository,
+        firestore,
+      );
+
+      final commentFirestore = commentsFirestore.first;
+      final userComment = userCommentsFirestore.first;
+
+      // Read the profile comments
+      final comments =
+          await container.read(userCommentsViewModelProvider.future);
+      expect(comments, hasLength(1));
+
+      // Check that the comment is exposed correctly
+      final comment = comments.first;
+      expect(comment.commentId, commentFirestore.id);
+      expect(comment.description, commentFirestore.data.content);
+      expect(
+        comment.parentPostId,
+        userComment.data.parentPostId,
+      );
+    });
   });
 }


### PR DESCRIPTION
Hello,
This PR aims to sort the user comments on the profile page (issue #300).

Concretelly, this PR does the following:

**Add `publicationTime` field to `UserCommentData`:**
A new field `publicationTime` has been added to the `UserCommentData` to allow for the sorting.
Thus, the repository `CommentRepositoryService` as well as the tests and mocks for `UserCommentData` have been updated to take into account this new field.

**User comments view model:**
The view model to display the user comments will now sort the comments from latest to oldest before exposing them.
Thus, the latest comments of the user wil appear at the top of the list on the profile page.


**Tests:**
This PR provides a test for the ordering of the user comments exposed by the view model.

#### Live testing
You can test this feature by doing the following:
In the application, add a new comment under any post then go into your profile page in the comment tab.
You should then see the newly added comment at the top. You can add more comments and you should see them appearing sorted from latest (top) to oldest (bottom) in the profile page.
<img src="https://github.com/ProximaEPFL/proxima/assets/79637838/b9d62610-0863-4f05-885d-050845367f1a" width=250 />

#### Acceptance criteria:
- [x] Sort the user's comments within the user profile, displaying the latest comments first.


**Note:**
Once this PR is merged, the comments on the database will need to be cleared because the structure `UserCommentData` has changed.

Thank you for reviewing this PR and I look forward to your feedback :+1: 