### PR TITLE
Refresh challenges

### DIFF
--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -13,7 +13,8 @@ import "package:proxima/viewmodels/login_view_model.dart";
 /// the challenges into [ChallengeDetails] objects to be displayed, by getting
 /// the posts from the post repository and calculating the distances as well as
 /// remaining time.
-class ChallengeViewModel extends AsyncNotifier<List<ChallengeDetails>> {
+class ChallengeViewModel
+    extends AutoDisposeAsyncNotifier<List<ChallengeDetails>> {
   @override
   Future<List<ChallengeDetails>> build() async {
     final geoLocationService = ref.watch(geolocationServiceProvider);
@@ -97,7 +98,7 @@ class ChallengeViewModel extends AsyncNotifier<List<ChallengeDetails>> {
   }
 }
 
-final challengeViewModelProvider =
-    AsyncNotifierProvider<ChallengeViewModel, List<ChallengeDetails>>(
+final challengeViewModelProvider = AutoDisposeAsyncNotifierProvider<
+    ChallengeViewModel, List<ChallengeDetails>>(
   () => ChallengeViewModel(),
 );

--- a/lib/viewmodels/challenge_view_model.dart
+++ b/lib/viewmodels/challenge_view_model.dart
@@ -13,6 +13,8 @@ import "package:proxima/viewmodels/login_view_model.dart";
 /// the challenges into [ChallengeDetails] objects to be displayed, by getting
 /// the posts from the post repository and calculating the distances as well as
 /// remaining time.
+/// It extends [AutoDisposeAsyncNotifier] to automatically dispose of the viewmodel
+/// so that the challenges are refreshed when the view is no longer visible.
 class ChallengeViewModel
     extends AutoDisposeAsyncNotifier<List<ChallengeDetails>> {
   @override

--- a/test/mocks/overrides/override_challenges_view_model.dart
+++ b/test/mocks/overrides/override_challenges_view_model.dart
@@ -5,7 +5,8 @@ import "package:proxima/viewmodels/challenge_view_model.dart";
 
 import "../data/challenge_list.dart";
 
-class MockChallengeViewModel extends AsyncNotifier<List<ChallengeDetails>>
+class MockChallengeViewModel
+    extends AutoDisposeAsyncNotifier<List<ChallengeDetails>>
     implements ChallengeViewModel {
   @override
   Future<List<ChallengeDetails>> build() async {

--- a/test/viewmodels/challenge_view_model_integration_test.dart
+++ b/test/viewmodels/challenge_view_model_integration_test.dart
@@ -114,7 +114,7 @@ void main() {
 
     test("Challenges are sorted correctly", () async {
       final posts = postGenerator.generatePostsAt(userPosition1, 3);
-      setPostsFirestore(posts, fakeFireStore);
+      await setPostsFirestore(posts, fakeFireStore);
 
       final finishedChallenges =
           challengeGenerator.generateChallenges(2, true, extraTime);
@@ -187,7 +187,7 @@ void main() {
     test("Challenges position is updated on user position change and refresh",
         () async {
       final posts = postGenerator.generatePostsAt(userPosition1, 3);
-      setPostsFirestore(posts, fakeFireStore);
+      await setPostsFirestore(posts, fakeFireStore);
 
       final activeChallenges =
           challengeGenerator.generateChallenges(1, false, extraTime);

--- a/test/viewmodels/challenge_view_model_integration_test.dart
+++ b/test/viewmodels/challenge_view_model_integration_test.dart
@@ -186,11 +186,11 @@ void main() {
 
     test("Challenges position is updated on user position change and refresh",
         () async {
-      final posts = postGenerator.generatePostsAt(userPosition1, 3);
-      await setPostsFirestore(posts, fakeFireStore);
+      const nbPosts = 3;
+      await postGenerator.addPosts(fakeFireStore, userPosition1, nbPosts);
 
       final activeChallenges =
-          challengeGenerator.generateChallenges(1, false, extraTime);
+          challengeGenerator.generateChallenges(nbPosts, false, extraTime);
 
       await setChallenges(
         fakeFireStore,
@@ -198,10 +198,11 @@ void main() {
         testingUserFirestoreId,
       );
 
-      var challenges = await container.read(challengeViewModelProvider.future);
+      final challengesBeforeRefresh =
+          await container.read(challengeViewModelProvider.future);
 
       // Check initial distances are 0 since user is at userPosition1
-      for (var challenge in challenges) {
+      for (final challenge in challengesBeforeRefresh) {
         expect(challenge.distance, 0);
       }
 
@@ -212,7 +213,8 @@ void main() {
 
       // Refresh challenges
       await container.read(challengeViewModelProvider.notifier).refresh();
-      challenges = await container.read(challengeViewModelProvider.future);
+      final challengesAfterRefresh =
+          await container.read(challengeViewModelProvider.future);
 
       // Compute the distance between userPosition1 and userPosition2
       final double distanceKm = const GeoFirePoint(userPosition1)
@@ -220,7 +222,7 @@ void main() {
       final int distanceM = (distanceKm * 1000).toInt();
 
       // Check that challenges distances are updated correctly
-      for (var challenge in challenges) {
+      for (final challenge in challengesAfterRefresh) {
         expect(challenge.distance, distanceM);
       }
     });

--- a/test/viewmodels/challenge_view_model_integration_test.dart
+++ b/test/viewmodels/challenge_view_model_integration_test.dart
@@ -22,6 +22,8 @@ void main() {
   late FakeFirebaseFirestore fakeFireStore;
   late ProviderContainer container;
 
+  const extraTime = Duration(hours: 2, minutes: 30);
+
   setUp(() {
     geoLocationService = MockGeolocationService();
     fakeFireStore = FakeFirebaseFirestore();
@@ -32,6 +34,8 @@ void main() {
 
   group("Normal use", () {
     late UserRepositoryService userRepo;
+    late FirestoreChallengeGenerator challengeGenerator;
+    late FirestorePostGenerator postGenerator;
 
     setUp(() async {
       container = ProviderContainer(
@@ -41,7 +45,8 @@ void main() {
           firestoreProvider.overrideWithValue(fakeFireStore),
         ],
       );
-
+      challengeGenerator = FirestoreChallengeGenerator();
+      postGenerator = FirestorePostGenerator();
       userRepo = container.read(userRepositoryServiceProvider);
     });
 
@@ -54,10 +59,6 @@ void main() {
     test(
         "`ChallengeFirestore` is transformed correctly into `ChallengeCardData`",
         () async {
-      const extraTime = Duration(hours: 2, minutes: 30);
-      final challengeGenerator = FirestoreChallengeGenerator();
-      final postGenerator = FirestorePostGenerator();
-
       final post = postGenerator.generatePostAt(
         userPosition1,
       ); // the challenge is added by hand, so we can use the user position
@@ -85,10 +86,6 @@ void main() {
     });
 
     test("Completed challenge is transformed correctly", () async {
-      const extraTime = Duration(hours: 2, minutes: 30);
-      final challengeGenerator = FirestoreChallengeGenerator();
-      final postGenerator = FirestorePostGenerator();
-
       final post = postGenerator.generatePostAt(
         userPosition1,
       ); // the challenge is added by hand, so we can use the user position
@@ -116,10 +113,6 @@ void main() {
     });
 
     test("Challenges are sorted correctly", () async {
-      const extraTime = Duration(hours: 2, minutes: 30);
-      final challengeGenerator = FirestoreChallengeGenerator();
-      final postGenerator = FirestorePostGenerator();
-
       final posts = postGenerator.generatePostsAt(userPosition1, 3);
       setPostsFirestore(posts, fakeFireStore);
 
@@ -152,10 +145,6 @@ void main() {
     });
 
     test("Challenge can be completed", () async {
-      const extraTime = Duration(hours: 2, minutes: 30);
-      final challengeGenerator = FirestoreChallengeGenerator();
-      final postGenerator = FirestorePostGenerator();
-
       await setUserFirestore(fakeFireStore, testingUserFirestore);
 
       final post = postGenerator.generatePostAt(
@@ -197,10 +186,6 @@ void main() {
 
     test("Challenges position is updated on user position change and refresh",
         () async {
-      const extraTime = Duration(hours: 2, minutes: 30);
-      final challengeGenerator = FirestoreChallengeGenerator();
-      final postGenerator = FirestorePostGenerator();
-
       final posts = postGenerator.generatePostsAt(userPosition1, 3);
       setPostsFirestore(posts, fakeFireStore);
 


### PR DESCRIPTION
Fixes #267.
This PR changes the widget used for the challenges viewmodel to `AutoDisposeAsyncNotifier`, so that the challenges are refreshed on bottom bar navigation.

**Features:**
- `ChallengeViewModel` now extends `AutoDisposeAsyncNotifier<List<ChallengeDetails>>`
- Extended `challenge_viewmodel_integration_test` to check that the distance are correctly updated on user position change and viewmodel refresh
- Checking that the distance is correctly updated on user position change on bottom bar navigation will be handled by #220, as it requires a significant update of our end-to-end tests, with proper setup. (this was discussed with @Aderfish)

**Live testing:**
To test the feature, you can 
1. Navigate to the challenges page, check the distance
2. Move
3. Go to another page and come back with bottom bar navigation
4. Check that the distance was updated

**Acceptance criteria:**
- [x] On navigation to the challenge page, the challenges information should be automatically refresh.