### PR TITLE
Fix post generator id increment

### DIFF
--- a/test/mocks/data/firestore_post.dart
+++ b/test/mocks/data/firestore_post.dart
@@ -15,6 +15,10 @@ import "post_data.dart";
 class FirestorePostGenerator {
   int _postId = 0;
 
+  int _nextPostId() {
+    return _postId++;
+  }
+
   /// Create a [PostFirestore] with given data
   PostFirestore createPostAt(
     PostData data,
@@ -23,7 +27,7 @@ class FirestorePostGenerator {
   }) {
     final point = GeoFirePoint(location);
 
-    id ??= (_postId++).toString();
+    id ??= _nextPostId().toString();
 
     return PostFirestore(
       id: PostIdFirestore(value: id),
@@ -65,11 +69,9 @@ class FirestorePostGenerator {
   ) {
     final point = GeoFirePoint(location);
 
-    _postId += 1;
-
     return PostFirestore(
       id: PostIdFirestore(
-        value: _postId.toString(),
+        value: _nextPostId().toString(),
       ),
       location: PostLocationFirestore(
         geoPoint: location,


### PR DESCRIPTION
Fixes #344.

This PR makes the handling of the indices by `FirestorePostGenerator` consistent. Before, one function incremented it before using it, and the other incremented it after using it. This therefore created bugs that were very hard to notice, which depended on the order of execution of those two functions. 

Happy reviewing, this should be a PR fast to review! ;)

Acceptance criteria:
- [x] All functions of `FirestorePostGenerator` should use the same convention, i.e. all increment the internal `id` before using, or increment the internal `id` after using it.