### PR TITLE
Fix offline vote throws an exception

### DIFF
--- a/lib/services/database/upvote_repository_service.dart
+++ b/lib/services/database/upvote_repository_service.dart
@@ -83,6 +83,8 @@ class UpvoteRepositoryService<ParentIdFirestore extends IdFirestore> {
     Transaction? transaction,
   }) async {
     final voteStateCollection = _votersCollection(parentId).doc(userId.value);
+
+    // Exception [cloud_firestore/unavailable] is thrown here when voting offline
     final voteState = transaction != null
         ? await transaction.get(voteStateCollection)
         : await voteStateCollection.get();

--- a/lib/services/database/upvote_repository_service.dart
+++ b/lib/services/database/upvote_repository_service.dart
@@ -84,10 +84,16 @@ class UpvoteRepositoryService<ParentIdFirestore extends IdFirestore> {
   }) async {
     final voteStateCollection = _votersCollection(parentId).doc(userId.value);
 
-    // Exception [cloud_firestore/unavailable] is thrown here when voting offline
-    final voteState = transaction != null
-        ? await transaction.get(voteStateCollection)
-        : await voteStateCollection.get();
+    final DocumentSnapshot<Map<String, dynamic>> voteState;
+    try {
+      // Exception `cloud_firestore/unavailable` (of type `FirebaseException`) is thrown here when voting offline
+      voteState = transaction != null
+          ? await transaction.get(voteStateCollection)
+          : await voteStateCollection.get();
+    } on FirebaseException {
+      // Do not handle voting a post when being offline, see issue #160
+      return VoteState.none;
+    }
 
     if (!voteState.exists) {
       return VoteState.none;

--- a/test/mocks/overrides/override_firebase_transaction.dart
+++ b/test/mocks/overrides/override_firebase_transaction.dart
@@ -1,0 +1,38 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+
+/// A mock class of a cloud firestore [Transaction].
+/// This mock will always throw the [FirebaseException] error
+/// when any of its method is called.
+/// It is used to test the offline error handling of our services.
+class MockErrorFirebaseTransaction implements Transaction {
+  static const _plugin = "mock_error_firebase_transaction";
+
+  @override
+  Transaction delete(DocumentReference<Object?> documentReference) {
+    throw FirebaseException(plugin: _plugin);
+  }
+
+  @override
+  Future<DocumentSnapshot<T>> get<T extends Object?>(
+    DocumentReference<T> documentReference,
+  ) {
+    throw FirebaseException(plugin: _plugin);
+  }
+
+  @override
+  Transaction set<T>(
+    DocumentReference<T> documentReference,
+    T data, [
+    SetOptions? options,
+  ]) {
+    throw FirebaseException(plugin: _plugin);
+  }
+
+  @override
+  Transaction update(
+    DocumentReference<Object?> documentReference,
+    Map<String, dynamic> data,
+  ) {
+    throw FirebaseException(plugin: _plugin);
+  }
+}


### PR DESCRIPTION
Fixes #160 

### Fix offline vote throws an exception

This PR aims to prevent the launch of an exception to the Flutter console when voting on a post without internet connectivity.

#### Bug reproducibility

The bug is 100% reproducible, follow the steps below (on commit d1ae708):

- Open the app (in debug mode to have access to the flutter console)
- Login if not already logged in
- Load the posts on the feed or create one if there are no posts nearby
- Turn off the internet connection of the device
- Try to upvote the post on the feed

#### Actual behavior

The following error is thrown on the Firebase console:

```txt
E/flutter (11839): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: [cloud_firestore/unavailable] The service is currently unavailable. This is a most likely a transient condition and may be corrected by retrying with a backoff.
E/flutter (11839): #0      FirebaseFirestoreHostApi.transactionGet (package:cloud_firestore_platform_interface/src/pigeon/messages.pigeon.dart:977:7)
E/flutter (11839): <asynchronous suspension>
E/flutter (11839): #1      MethodChannelTransaction.get (package:cloud_firestore_platform_interface/src/method_channel/method_channel_transaction.dart:50:22)
E/flutter (11839): <asynchronous suspension>
E/flutter (11839): #2      Transaction.get (package:cloud_firestore/src/transaction.dart:28:9)
E/flutter (11839): <asynchronous suspension>
E/flutter (11839): #3      UpvoteRepositoryService.getUpvoteState (package:proxima/services/database/upvote_repository_service.dart:87:11)
E/flutter (11839): <asynchronous suspension>
E/flutter (11839): #4      UpvoteRepositoryService.setUpvoteState.<anonymous closure> (package:proxima/services/database/upvote_repository_service.dart:107:25)
E/flutter (11839): <asynchronous suspension>
E/flutter (11839): #5      FirebaseFirestore.runTransaction.<anonymous closure> (package:cloud_firestore/src/firestore.dart:273:18)
E/flutter (11839): <asynchronous suspension>
E/flutter (11839): #6      MethodChannelFirebaseFirestore.runTransaction.<anonymous closure> (package:cloud_firestore_platform_interface/src/method_channel/method_channel_firestore.dart:277:20)
E/flutter (11839): <asynchronous suspension>
```

#### Expected behavior (acceptance criteria)

- [X] No error thrown when upvoting offline

#### Regression test

This PR also introduces a regression test in `test/services/database/post_upvote_repository_test.dart`.

It makes use of a mocked Firebase cloud firestore transaction `MockErrorFirebaseTransaction` that returns the offline error when applied.

**Note**: I noticed that such errors might get thrown in other places of the codebase. In an effort to keep this PR short and self-contained, I only fixed the related error that I was assigned in issue #160. We might want to patch similar errors in future tasks (they are not user facing errors, so not critical).