### PR TITLE
Test account and comment validation

### DIFF
--- a/test/models/ui/validation/create_account_validation_test.dart
+++ b/test/models/ui/validation/create_account_validation_test.dart
@@ -34,7 +34,6 @@ void main() {
         accountCreated: true,
       );
 
-      expect(createAccount, createAccountCopy);
       expect(createAccount == createAccountCopy, true);
     });
 

--- a/test/models/ui/validation/create_account_validation_test.dart
+++ b/test/models/ui/validation/create_account_validation_test.dart
@@ -35,6 +35,55 @@ void main() {
       );
 
       expect(createAccount, createAccountCopy);
+      expect(createAccount == createAccountCopy, true);
+    });
+
+    test("equality fails on different uniqueUsernameError", () {
+      const createAccount = CreateAccountValidation(
+        uniqueUsernameError: "uniqueUsernameError",
+        pseudoError: "pseudoError",
+        accountCreated: true,
+      );
+
+      const createAccountCopy = CreateAccountValidation(
+        uniqueUsernameError: "uniqueUsernameError2",
+        pseudoError: "pseudoError",
+        accountCreated: true,
+      );
+
+      expect(createAccount == createAccountCopy, false);
+    });
+
+    test("equality fails on different pseudoError", () {
+      const createAccount = CreateAccountValidation(
+        uniqueUsernameError: "uniqueUsernameError",
+        pseudoError: "pseudoError",
+        accountCreated: true,
+      );
+
+      const createAccountCopy = CreateAccountValidation(
+        uniqueUsernameError: "uniqueUsernameError",
+        pseudoError: "pseudoError2",
+        accountCreated: true,
+      );
+
+      expect(createAccount == createAccountCopy, false);
+    });
+
+    test("equality fails on different accountCreated", () {
+      const createAccount = CreateAccountValidation(
+        uniqueUsernameError: "uniqueUsernameError",
+        pseudoError: "pseudoError",
+        accountCreated: true,
+      );
+
+      const createAccountCopy = CreateAccountValidation(
+        uniqueUsernameError: "uniqueUsernameError",
+        pseudoError: "pseudoError",
+        accountCreated: false,
+      );
+
+      expect(createAccount == createAccountCopy, false);
     });
   });
 }

--- a/test/models/ui/validation/new_comment_validation_test.dart
+++ b/test/models/ui/validation/new_comment_validation_test.dart
@@ -1,0 +1,69 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:proxima/models/ui/validation/new_comment_validation.dart";
+
+void main() {
+  group("New Comment Model Testing", () {
+    test("hash overrides correctly", () {
+      // Define the expected result
+      final newCommentState = NewCommentValidation(
+        contentError: "contentError",
+        posted: true,
+      );
+
+      final expectedHash = Object.hash(
+        newCommentState.contentError,
+        newCommentState.posted,
+      );
+
+      final actualHash = newCommentState.hashCode;
+
+      expect(actualHash, expectedHash);
+    });
+
+    test("equality overrides correctly", () {
+      // Define the expected result
+      final newCommentState = NewCommentValidation(
+        contentError: "commentError",
+        posted: true,
+      );
+
+      final newCommentStateCopy = NewCommentValidation(
+        contentError: "commentError",
+        posted: true,
+      );
+
+      expect(newCommentState, newCommentStateCopy);
+      expect(newCommentState == newCommentStateCopy, true);
+    });
+
+    test("equality fails on different contentError", () {
+      // Define the expected result
+      final newCommentState = NewCommentValidation(
+        contentError: "commentError",
+        posted: true,
+      );
+
+      final newCommentStateCopy = NewCommentValidation(
+        contentError: "commentError2",
+        posted: true,
+      );
+
+      expect(newCommentState == newCommentStateCopy, false);
+    });
+
+    test("equality fails on different posted", () {
+      // Define the expected result
+      final newCommentState = NewCommentValidation(
+        contentError: "commentError",
+        posted: true,
+      );
+
+      final newCommentStateCopy = NewCommentValidation(
+        contentError: "commentError",
+        posted: false,
+      );
+
+      expect(newCommentState == newCommentStateCopy, false);
+    });
+  });
+}

--- a/test/models/ui/validation/new_comment_validation_test.dart
+++ b/test/models/ui/validation/new_comment_validation_test.dart
@@ -32,7 +32,6 @@ void main() {
         posted: true,
       );
 
-      expect(newCommentState, newCommentStateCopy);
       expect(newCommentState == newCommentStateCopy, true);
     });
 

--- a/test/models/ui/validation/new_comment_validation_test.dart
+++ b/test/models/ui/validation/new_comment_validation_test.dart
@@ -5,7 +5,7 @@ void main() {
   group("New Comment Model Testing", () {
     test("hash overrides correctly", () {
       // Define the expected result
-      final newCommentState = NewCommentValidation(
+      const newCommentState = NewCommentValidation(
         contentError: "contentError",
         posted: true,
       );
@@ -22,12 +22,12 @@ void main() {
 
     test("equality overrides correctly", () {
       // Define the expected result
-      final newCommentState = NewCommentValidation(
+      const newCommentState = NewCommentValidation(
         contentError: "commentError",
         posted: true,
       );
 
-      final newCommentStateCopy = NewCommentValidation(
+      const newCommentStateCopy = NewCommentValidation(
         contentError: "commentError",
         posted: true,
       );
@@ -37,12 +37,12 @@ void main() {
 
     test("equality fails on different contentError", () {
       // Define the expected result
-      final newCommentState = NewCommentValidation(
+      const newCommentState = NewCommentValidation(
         contentError: "commentError",
         posted: true,
       );
 
-      final newCommentStateCopy = NewCommentValidation(
+      const newCommentStateCopy = NewCommentValidation(
         contentError: "commentError2",
         posted: true,
       );
@@ -52,12 +52,12 @@ void main() {
 
     test("equality fails on different posted", () {
       // Define the expected result
-      final newCommentState = NewCommentValidation(
+      const newCommentState = NewCommentValidation(
         contentError: "commentError",
         posted: true,
       );
 
-      final newCommentStateCopy = NewCommentValidation(
+      const newCommentStateCopy = NewCommentValidation(
         contentError: "commentError",
         posted: false,
       );

--- a/test/models/ui/validation/new_post_validation_test.dart
+++ b/test/models/ui/validation/new_post_validation_test.dart
@@ -2,7 +2,7 @@ import "package:flutter_test/flutter_test.dart";
 import "package:proxima/models/ui/validation/new_post_validation.dart";
 
 void main() {
-  group("Create Account Model testing", () {
+  group("New Post Model testing", () {
     test("hash overrides correctly", () {
       final newPostState = NewPostValidation(
         titleError: "titleError",


### PR DESCRIPTION
This small PR tests hashcode and equality overrides that were not covered until now. 

Acceptance criteria: 

- [x] Test the hashcode override for the classes `CreateAccountValidation` and `NewCommentValidation`
- [x] Test the equality override for the classes `CreateAccountValidation` and `NewCommentValidation`